### PR TITLE
100% CodeCoverage for SectionField/ValueObjects :smile:

### DIFF
--- a/src/SectionField/ValueObject/GeneratorConfig.php
+++ b/src/SectionField/ValueObject/GeneratorConfig.php
@@ -35,7 +35,7 @@ final class GeneratorConfig
 
     public function __toString(): string
     {
-        return ArrayConverter::recursive($this->sectionGeneratorConfig['generator']);
+        return ArrayConverter::recursive($this->sectionGeneratorConfig);
     }
 
     public static function fromArray(array $sectionGeneratorConfig): self

--- a/test/unit/SectionField/ValueObject/AfterTest.php
+++ b/test/unit/SectionField/ValueObject/AfterTest.php
@@ -46,4 +46,16 @@ class AfterTest extends TestCase
         );
         After::fromString('two thousand-Dec-12T12:01');
     }
+
+    /**
+     * @test
+     * @covers ::__toString
+     */
+    public function it_should_be_treatable_as_a_string()
+    {
+        $datetime = new \DateTime();
+        $afterString = (string)After::fromDateTime($datetime);
+        $dateString = $datetime->format('Y-m-d\TH:i');
+        $this->assertSame($afterString, $dateString);
+    }
 }

--- a/test/unit/SectionField/ValueObject/AfterTest.php
+++ b/test/unit/SectionField/ValueObject/AfterTest.php
@@ -56,6 +56,6 @@ class AfterTest extends TestCase
         $datetime = new \DateTime();
         $afterString = (string)After::fromDateTime($datetime);
         $dateString = $datetime->format('Y-m-d\TH:i');
-        $this->assertSame($afterString, $dateString);
+        $this->assertSame($dateString, $afterString);
     }
 }

--- a/test/unit/SectionField/ValueObject/ApplicationConfigTest.php
+++ b/test/unit/SectionField/ValueObject/ApplicationConfigTest.php
@@ -112,12 +112,12 @@ class ApplicationConfigTest extends TestCase
             ]
         ];
 
-        $expected = "application:" . PHP_EOL
-                  . "- name:sexy" . PHP_EOL
-                  . "- handle:field" . PHP_EOL
-                  . "- languages:" . PHP_EOL
-                  . "-- 0:this one" . PHP_EOL
-                  . "-- 1:that other one" . PHP_EOL;
+        $expected = "application:\n"
+                  . "- name:sexy\n"
+                  . "- handle:field\n"
+                  . "- languages:\n"
+                  . "-- 0:this one\n"
+                  . "-- 1:that other one\n";
 
         $applicationConfigString = (string)ApplicationConfig::fromArray($appConfig);
         $this->assertSame($expected, $applicationConfigString);

--- a/test/unit/SectionField/ValueObject/ApplicationConfigTest.php
+++ b/test/unit/SectionField/ValueObject/ApplicationConfigTest.php
@@ -4,6 +4,7 @@ declare (strict_types=1);
 namespace Tardigrades\SectionField\ValueObject;
 
 use PHPUnit\Framework\TestCase;
+use Tardigrades\Helper\ArrayConverter;
 
 /**
  * @coversDefaultClass Tardigrades\SectionField\ValueObject\ApplicationConfig
@@ -94,5 +95,26 @@ class ApplicationConfigTest extends TestCase
             ]
         ];
         ApplicationConfig::fromArray($appConfig);
+    }
+
+    /**
+     * @test
+     * @covers ::__toString
+     */
+    public function it_should_be_treatable_as_a_string()
+    {
+        $appConfig = [
+            'application' => [
+                'name' => 'sexy',
+                'handle' => 'field',
+                'languages' => [
+                    'this one', 'that other one'
+                ]
+            ]
+        ];
+
+        $applicationConfigString = (string)ApplicationConfig::fromArray($appConfig);
+        $appConfigString = ArrayConverter::recursive($appConfig);
+        $this->assertSame($applicationConfigString, $appConfigString);
     }
 }

--- a/test/unit/SectionField/ValueObject/ApplicationConfigTest.php
+++ b/test/unit/SectionField/ValueObject/ApplicationConfigTest.php
@@ -4,7 +4,6 @@ declare (strict_types=1);
 namespace Tardigrades\SectionField\ValueObject;
 
 use PHPUnit\Framework\TestCase;
-use Tardigrades\Helper\ArrayConverter;
 
 /**
  * @coversDefaultClass Tardigrades\SectionField\ValueObject\ApplicationConfig
@@ -31,7 +30,7 @@ class ApplicationConfigTest extends TestCase
         ];
         $applicationConfig = ApplicationConfig::fromArray($appConfig);
         $this->assertInstanceOf(ApplicationConfig::class, $applicationConfig);
-        $this->assertSame($applicationConfig->toArray(), $appConfig);
+        $this->assertSame($appConfig, $applicationConfig->toArray());
     }
 
     /**
@@ -113,8 +112,14 @@ class ApplicationConfigTest extends TestCase
             ]
         ];
 
+        $expected = "application:" . PHP_EOL
+                  . "- name:sexy" . PHP_EOL
+                  . "- handle:field" . PHP_EOL
+                  . "- languages:" . PHP_EOL
+                  . "-- 0:this one" . PHP_EOL
+                  . "-- 1:that other one" . PHP_EOL;
+
         $applicationConfigString = (string)ApplicationConfig::fromArray($appConfig);
-        $appConfigString = ArrayConverter::recursive($appConfig);
-        $this->assertSame($applicationConfigString, $appConfigString);
+        $this->assertSame($expected, $applicationConfigString);
     }
 }

--- a/test/unit/SectionField/ValueObject/BeforeTest.php
+++ b/test/unit/SectionField/ValueObject/BeforeTest.php
@@ -56,6 +56,6 @@ class BeforeTest extends TestCase
         $datetime = new \DateTime();
         $beforeString = (string)Before::fromDateTime($datetime);
         $dateString = $datetime->format('Y-m-d\TH:i');
-        $this->assertSame($beforeString, $dateString);
+        $this->assertSame($dateString, $beforeString);
     }
 }

--- a/test/unit/SectionField/ValueObject/BeforeTest.php
+++ b/test/unit/SectionField/ValueObject/BeforeTest.php
@@ -46,4 +46,16 @@ class BeforeTest extends TestCase
         );
         Before::fromString('two thousand-Dec-12T12:01');
     }
+
+    /**
+     * @test
+     * @covers ::__toString
+     */
+    public function it_should_be_treatable_as_a_string()
+    {
+        $datetime = new \DateTime();
+        $beforeString = (string)Before::fromDateTime($datetime);
+        $dateString = $datetime->format('Y-m-d\TH:i');
+        $this->assertSame($beforeString, $dateString);
+    }
 }

--- a/test/unit/SectionField/ValueObject/ClassNameTest.php
+++ b/test/unit/SectionField/ValueObject/ClassNameTest.php
@@ -1,0 +1,46 @@
+<?php
+declare (strict_types=1);
+
+namespace Tardigrades\SectionField\ValueObject;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass Tardigrades\SectionField\ValueObject\ClassName
+ * @covers ::<private>
+ * @covers ::__construct
+ */
+class ClassNameTest extends TestCase
+{
+    /**
+     * @test
+     * @covers ::fromString
+     * @covers ::__toString
+     */
+    public function it_should_create_from_string()
+    {
+        $string = 'a sexy camel';
+        $propertyName = ClassName::fromString($string);
+        $this->assertInstanceOf(ClassName::class, $propertyName);
+        $this->assertSame('ASexyCamel', (string) $propertyName);
+    }
+    /**
+     * @test
+     * @covers ::__toString
+     */
+    public function it_should_be_treatable_as_a_string()
+    {
+        $propertyNameString = (string)ClassName::fromString('a sexy camel');
+        $this->assertSame('ASexyCamel', $propertyNameString);
+
+        $propertyNameString = (string)ClassName::fromString('a-sexy-camel');
+        $this->assertSame('ASexyCamel', $propertyNameString);
+
+        $propertyNameString = (string)ClassName::fromString('a_sexy_camel');
+        $this->assertSame('ASexyCamel', $propertyNameString);
+
+        $propertyNameString = (string)ClassName::fromString('a.sexy.camel');
+        $this->assertSame('A.sexy.camel', $propertyNameString);
+    }
+
+}

--- a/test/unit/SectionField/ValueObject/CreatedFieldTest.php
+++ b/test/unit/SectionField/ValueObject/CreatedFieldTest.php
@@ -31,4 +31,15 @@ class CreatedFieldTest extends TestCase
         $this->expectExceptionMessage('Value is not specified');
         CreatedField::fromString('');
     }
+
+    /**
+     * @test
+     * @covers ::__toString
+     */
+    public function it_should_be_treatable_as_a_string()
+    {
+        $string = 'I am a created field!';
+        $createdFieldString = (string)CreatedField::fromString($string);
+        $this->assertSame($createdFieldString, $string);
+    }
 }

--- a/test/unit/SectionField/ValueObject/CreatedFieldTest.php
+++ b/test/unit/SectionField/ValueObject/CreatedFieldTest.php
@@ -40,6 +40,6 @@ class CreatedFieldTest extends TestCase
     {
         $string = 'I am a created field!';
         $createdFieldString = (string)CreatedField::fromString($string);
-        $this->assertSame($createdFieldString, $string);
+        $this->assertSame($string, $createdFieldString);
     }
 }

--- a/test/unit/SectionField/ValueObject/CreatedTest.php
+++ b/test/unit/SectionField/ValueObject/CreatedTest.php
@@ -25,4 +25,16 @@ class CreatedTest extends TestCase
         $this->assertEquals($created->getDateTime(), new \DateTime('2000-11-11T12:12:12'));
         $this->assertEquals((string) $created, '2000-11-11T12:12');
     }
+
+    /**
+     * @test
+     * @covers ::__toString
+     */
+    public function it_should_be_treatable_as_a_string()
+    {
+        $datetime = new \DateTime();
+        $afterString = (string)Created::fromDateTime($datetime);
+        $dateString = $datetime->format('Y-m-d\TH:i');
+        $this->assertSame($afterString, $dateString);
+    }
 }

--- a/test/unit/SectionField/ValueObject/CreatedTest.php
+++ b/test/unit/SectionField/ValueObject/CreatedTest.php
@@ -35,6 +35,6 @@ class CreatedTest extends TestCase
         $datetime = new \DateTime();
         $afterString = (string)Created::fromDateTime($datetime);
         $dateString = $datetime->format('Y-m-d\TH:i');
-        $this->assertSame($afterString, $dateString);
+        $this->assertSame($dateString, $afterString);
     }
 }

--- a/test/unit/SectionField/ValueObject/FieldConfigTest.php
+++ b/test/unit/SectionField/ValueObject/FieldConfigTest.php
@@ -4,6 +4,7 @@ declare (strict_types=1);
 namespace Tardigrades\SectionField\ValueObject;
 
 use PHPUnit\Framework\TestCase;
+use Tardigrades\Helper\ArrayConverter;
 
 /**
  * @coversDefaultClass Tardigrades\SectionField\ValueObject\FieldConfig
@@ -232,5 +233,22 @@ class FieldConfigTest extends TestCase
             ]
         ];
         FieldConfig::fromArray($fieldConfig)->getEntityEvents();
+    }
+
+    /**
+     * @test
+     * @covers ::__toString
+     */
+    public function it_should_be_treatable_as_a_string()
+    {
+        $fieldConfig = [
+            'field' => [
+                'name' => 'sexy name',
+                'handle' => 'sexy handles'
+            ]
+        ];
+        $fConfigString = (string)FieldConfig::fromArray($fieldConfig);
+        $fieldConfigString = ArrayConverter::recursive($fieldConfig['field']);
+        $this->assertSame($fConfigString, $fieldConfigString);
     }
 }

--- a/test/unit/SectionField/ValueObject/FieldConfigTest.php
+++ b/test/unit/SectionField/ValueObject/FieldConfigTest.php
@@ -248,8 +248,8 @@ class FieldConfigTest extends TestCase
             ]
         ];
 
-        $expected = "name:sexy name" . PHP_EOL
-                  . "handle:sexy handles" . PHP_EOL;
+        $expected = "name:sexy name\n"
+                  . "handle:sexy handles\n";
 
         $fConfigString = (string)FieldConfig::fromArray($fieldConfig);
         $this->assertSame($expected, $fConfigString);

--- a/test/unit/SectionField/ValueObject/FieldConfigTest.php
+++ b/test/unit/SectionField/ValueObject/FieldConfigTest.php
@@ -247,8 +247,11 @@ class FieldConfigTest extends TestCase
                 'handle' => 'sexy handles'
             ]
         ];
+
+        $expected = "name:sexy name" . PHP_EOL
+                  . "handle:sexy handles" . PHP_EOL;
+
         $fConfigString = (string)FieldConfig::fromArray($fieldConfig);
-        $fieldConfigString = ArrayConverter::recursive($fieldConfig['field']);
-        $this->assertSame($fConfigString, $fieldConfigString);
+        $this->assertSame($expected, $fConfigString);
     }
 }

--- a/test/unit/SectionField/ValueObject/FieldMetadataTest.php
+++ b/test/unit/SectionField/ValueObject/FieldMetadataTest.php
@@ -24,7 +24,7 @@ class FieldMetadataTest extends TestCase
             'meta' => 'data',
             'data' => 'meta'
         ];
-        $this->assertSame(FieldMetadata::fromArray($array)->toArray(),$array);
+        $this->assertSame($array, FieldMetadata::fromArray($array)->toArray());
     }
 
     /**
@@ -38,8 +38,10 @@ class FieldMetadataTest extends TestCase
             'data' => 'meta'
         ];
 
+        $expected = "meta:data" . PHP_EOL
+                  . "data:meta" . PHP_EOL;
+
         $fieldMetadataString = (string)FieldMetadata::fromArray($array);
-        $string = ArrayConverter::recursive($array);
-        $this->assertSame($fieldMetadataString, $string);
+        $this->assertSame($expected, $fieldMetadataString);
     }
 }

--- a/test/unit/SectionField/ValueObject/FieldMetadataTest.php
+++ b/test/unit/SectionField/ValueObject/FieldMetadataTest.php
@@ -4,6 +4,7 @@ declare (strict_types=1);
 namespace Tardigrades\SectionField\ValueObject;
 
 use PHPUnit\Framework\TestCase;
+use Tardigrades\Helper\ArrayConverter;
 
 /**
  * @coversDefaultClass Tardigrades\SectionField\ValueObject\FieldMetadata
@@ -24,5 +25,21 @@ class FieldMetadataTest extends TestCase
             'data' => 'meta'
         ];
         $this->assertSame(FieldMetadata::fromArray($array)->toArray(),$array);
+    }
+
+    /**
+     * @test
+     * @covers ::__toString
+     */
+    public function it_should_be_treatable_as_a_string()
+    {
+        $array = [
+            'meta' => 'data',
+            'data' => 'meta'
+        ];
+
+        $fieldMetadataString = (string)FieldMetadata::fromArray($array);
+        $string = ArrayConverter::recursive($array);
+        $this->assertSame($fieldMetadataString, $string);
     }
 }

--- a/test/unit/SectionField/ValueObject/FieldMetadataTest.php
+++ b/test/unit/SectionField/ValueObject/FieldMetadataTest.php
@@ -38,8 +38,8 @@ class FieldMetadataTest extends TestCase
             'data' => 'meta'
         ];
 
-        $expected = "meta:data" . PHP_EOL
-                  . "data:meta" . PHP_EOL;
+        $expected = "meta:data\n"
+                  . "data:meta\n";
 
         $fieldMetadataString = (string)FieldMetadata::fromArray($array);
         $this->assertSame($expected, $fieldMetadataString);

--- a/test/unit/SectionField/ValueObject/FieldTypeGeneratorConfigTest.php
+++ b/test/unit/SectionField/ValueObject/FieldTypeGeneratorConfigTest.php
@@ -4,6 +4,7 @@ declare (strict_types=1);
 namespace Tardigrades\SectionField\ValueObject;
 
 use PHPUnit\Framework\TestCase;
+use Tardigrades\Helper\ArrayConverter;
 
 /**
  * @coversDefaultClass Tardigrades\SectionField\ValueObject\FieldTypeGeneratorConfig
@@ -23,5 +24,20 @@ class FieldTypeGeneratorConfigTest extends TestCase
             'some sexy index' => 'sexy content'
         ];
         $this->assertSame(FieldTypeGeneratorConfig::fromArray($array)->toArray(),$array);
+    }
+
+    /**
+     * @test
+     * @covers ::__toString
+     */
+    public function it_should_be_treatable_as_a_string()
+    {
+        $array = [
+            'some sexy index' => 'sexy content'
+        ];
+
+        $fieldTypeGeneratorConfig = (string)FieldTypeGeneratorConfig::fromArray($array);
+        $string = ArrayConverter::recursive($array);
+        $this->assertSame($fieldTypeGeneratorConfig, $string);
     }
 }

--- a/test/unit/SectionField/ValueObject/FieldTypeGeneratorConfigTest.php
+++ b/test/unit/SectionField/ValueObject/FieldTypeGeneratorConfigTest.php
@@ -23,7 +23,7 @@ class FieldTypeGeneratorConfigTest extends TestCase
         $array = [
             'some sexy index' => 'sexy content'
         ];
-        $this->assertSame(FieldTypeGeneratorConfig::fromArray($array)->toArray(),$array);
+        $this->assertSame($array, FieldTypeGeneratorConfig::fromArray($array)->toArray());
     }
 
     /**
@@ -37,7 +37,6 @@ class FieldTypeGeneratorConfigTest extends TestCase
         ];
 
         $fieldTypeGeneratorConfig = (string)FieldTypeGeneratorConfig::fromArray($array);
-        $string = ArrayConverter::recursive($array);
-        $this->assertSame($fieldTypeGeneratorConfig, $string);
+        $this->assertSame('some sexy index:sexy content' . PHP_EOL, $fieldTypeGeneratorConfig);
     }
 }

--- a/test/unit/SectionField/ValueObject/FieldTypeGeneratorConfigTest.php
+++ b/test/unit/SectionField/ValueObject/FieldTypeGeneratorConfigTest.php
@@ -37,6 +37,6 @@ class FieldTypeGeneratorConfigTest extends TestCase
         ];
 
         $fieldTypeGeneratorConfig = (string)FieldTypeGeneratorConfig::fromArray($array);
-        $this->assertSame('some sexy index:sexy content' . PHP_EOL, $fieldTypeGeneratorConfig);
+        $this->assertSame("some sexy index:sexy content\n", $fieldTypeGeneratorConfig);
     }
 }

--- a/test/unit/SectionField/ValueObject/FullyQualifiedClassNameTest.php
+++ b/test/unit/SectionField/ValueObject/FullyQualifiedClassNameTest.php
@@ -38,4 +38,16 @@ class FullyQualifiedClassNameTest extends TestCase
         $this->assertInstanceOf(FullyQualifiedClassName::class, $fullyQualifiedSexyClassName);
         $this->assertSame($fullyQualifiedSexyClassName->getClassName(), 'Sexyclass');
     }
+
+    /**
+     * @test
+     * @covers ::__toString
+     */
+    public function it_should_be_treatable_as_a_string()
+    {
+        $sexyString = 'sexy.class';
+        $fullyQualifiedSexyClassNameString = (string)FullyQualifiedClassName::fromString($sexyString);
+        $sexyClassName = str_replace('.', '\\', $sexyString);
+        $this->assertSame($sexyClassName, $fullyQualifiedSexyClassNameString);
+    }
 }

--- a/test/unit/SectionField/ValueObject/FullyQualifiedClassNameTest.php
+++ b/test/unit/SectionField/ValueObject/FullyQualifiedClassNameTest.php
@@ -36,7 +36,7 @@ class FullyQualifiedClassNameTest extends TestCase
         $classname = ClassName::fromString('Sexyclass');
         $fullyQualifiedSexyClassName = FullyQualifiedClassName::fromNamespaceAndClassName($namespace, $classname);
         $this->assertInstanceOf(FullyQualifiedClassName::class, $fullyQualifiedSexyClassName);
-        $this->assertSame($fullyQualifiedSexyClassName->getClassName(), 'Sexyclass');
+        $this->assertSame('Sexyclass', $fullyQualifiedSexyClassName->getClassName());
     }
 
     /**
@@ -47,7 +47,6 @@ class FullyQualifiedClassNameTest extends TestCase
     {
         $sexyString = 'sexy.class';
         $fullyQualifiedSexyClassNameString = (string)FullyQualifiedClassName::fromString($sexyString);
-        $sexyClassName = str_replace('.', '\\', $sexyString);
-        $this->assertSame($sexyClassName, $fullyQualifiedSexyClassNameString);
+        $this->assertSame('sexy\class', $fullyQualifiedSexyClassNameString);
     }
 }

--- a/test/unit/SectionField/ValueObject/GeneratorConfigTest.php
+++ b/test/unit/SectionField/ValueObject/GeneratorConfigTest.php
@@ -4,6 +4,7 @@ declare (strict_types=1);
 namespace Tardigrades\SectionField\ValueObject;
 
 use PHPUnit\Framework\TestCase;
+use Tardigrades\Helper\ArrayConverter;
 
 /**
  * @coversDefaultClass Tardigrades\SectionField\ValueObject\GeneratorConfig
@@ -40,5 +41,20 @@ class GeneratorConfigTest extends TestCase
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Config is not a section config');
         GeneratorConfig::fromArray($array);
+    }
+
+    /**
+     * @test
+     * @covers ::__toString
+     */
+    public function it_should_be_treatable_as_a_string()
+    {
+        $array = ['generator' =>
+            ['sexyGenerator' => 'something']
+        ];
+        $sexyGeneratorConfigString = (string)GeneratorConfig::fromArray($array);
+        $arrayString = ArrayConverter::recursive($array['generator']);
+
+        $this->assertSame($arrayString, $sexyGeneratorConfigString);
     }
 }

--- a/test/unit/SectionField/ValueObject/HandleTest.php
+++ b/test/unit/SectionField/ValueObject/HandleTest.php
@@ -22,4 +22,16 @@ class HandleTest extends TestCase
         $this->assertInstanceOf(Handle::class, $thing);
         $this->assertSame((string)$thing, 'wheeeeeee! handles!');
     }
+
+    /**
+     * @test
+     * @covers ::__toString
+     */
+    public function it_should_be_treatable_as_a_string()
+    {
+        $string = 'wheeeeeee! handles!';
+        $thing = (string)Handle::fromString($string);
+
+        $this->assertSame($string, $thing);
+    }
 }

--- a/test/unit/SectionField/ValueObject/I18nTest.php
+++ b/test/unit/SectionField/ValueObject/I18nTest.php
@@ -22,4 +22,16 @@ class I18nTest extends TestCase
         $this->assertInstanceOf(I18n::class, $thing);
         $this->assertSame((string)$thing, 'I am something which I do not really understand');
     }
+
+    /**
+     * @test
+     * @covers ::__toString
+     */
+    public function it_should_be_treatable_as_a_string()
+    {
+        $string = 'wheeeéeeè!';
+        $thing = (string)I18n::fromString($string);
+
+        $this->assertSame($string, $thing);
+    }
 }

--- a/test/unit/SectionField/ValueObject/IdTest.php
+++ b/test/unit/SectionField/ValueObject/IdTest.php
@@ -17,12 +17,14 @@ class IdTest extends TestCase
      * @covers ::fromInt
      * @covers ::getId
      * @covers ::toInt
+     * @covers ::__toString
      */
     public function it_should_create_from_int()
     {
         $thing = Id::fromInt(1234567890);
         $this->assertInstanceOf(Id::class, $thing);
-        $this->assertSame($thing->toInt(), 1234567890);
-        $this->assertSame($thing->getId(), 1234567890);
+        $this->assertSame(1234567890, $thing->toInt());
+        $this->assertSame(1234567890, $thing->getId());
+        $this->assertSame('1234567890', (string)$thing);
     }
 }

--- a/test/unit/SectionField/ValueObject/LabelTest.php
+++ b/test/unit/SectionField/ValueObject/LabelTest.php
@@ -20,6 +20,19 @@ class LabelTest extends TestCase
     {
         $sexyLabel = Label::fromString('labelicious');
         $this->assertInstanceOf(Label::class, $sexyLabel);
-        $this->assertSame((string) $sexyLabel, 'labelicious');
+        $this->assertSame('labelicious', (string) $sexyLabel);
+    }
+
+
+    /**
+     * @test
+     * @covers ::__toString
+     */
+    public function it_should_be_treatable_as_a_string()
+    {
+        $string = 'labelicious';
+        $thing = (string)Label::fromString($string);
+
+        $this->assertSame($string, $thing);
     }
 }

--- a/test/unit/SectionField/ValueObject/LanguageConfigTest.php
+++ b/test/unit/SectionField/ValueObject/LanguageConfigTest.php
@@ -55,4 +55,15 @@ class LanguageConfigTest extends TestCase
         ];
         LanguageConfig::fromArray($array);
     }
+
+    /**
+     * @test
+     * @covers ::__toString
+     */
+    public function it_should_be_treatable_as_a_string()
+    {
+        $application['language'] = ['nl_NL', 'en_EN'];
+        $languageConfigString = (string)LanguageConfig::fromArray($application);
+        $this->assertSame("0:nl_NL\n1:en_EN\n", $languageConfigString);
+    }
 }

--- a/test/unit/SectionField/ValueObject/LimitTest.php
+++ b/test/unit/SectionField/ValueObject/LimitTest.php
@@ -21,6 +21,6 @@ class LimitTest extends TestCase
     {
         $limit = Limit::fromInt(666);
         $this->assertInstanceOf(Limit::class, $limit);
-        $this->assertSame($limit->toInt(), 666);
+        $this->assertSame(666, $limit->toInt());
     }
 }

--- a/test/unit/SectionField/ValueObject/MethodNameTest.php
+++ b/test/unit/SectionField/ValueObject/MethodNameTest.php
@@ -20,6 +20,25 @@ class MethodNameTest extends TestCase
     {
         $string = 'sexy method';
         $this->assertInstanceOf(MethodName::class, MethodName::fromString($string));
-        $this->assertSame((string) MethodName::fromString($string), 'SexyMethod');
+        $this->assertSame('SexyMethod', (string) MethodName::fromString($string));
+    }
+
+    /**
+     * @test
+     * @covers ::__toString
+     */
+    public function it_should_be_treatable_as_a_string()
+    {
+        $methodNameString = (string)MethodName::fromString('sexy method');
+        $this->assertSame('SexyMethod', $methodNameString);
+
+        $methodNameString = (string)MethodName::fromString('sexy-method');
+        $this->assertSame('SexyMethod', $methodNameString);
+
+        $methodNameString = (string)MethodName::fromString('sexy.method');
+        $this->assertSame('Sexy.method', $methodNameString);
+
+        $methodNameString = (string)MethodName::fromString('sexy_method');
+        $this->assertSame('SexyMethod', $methodNameString);
     }
 }

--- a/test/unit/SectionField/ValueObject/NameTest.php
+++ b/test/unit/SectionField/ValueObject/NameTest.php
@@ -20,6 +20,18 @@ class NameTest extends TestCase
     {
         $string = 'sexy name';
         $this->assertInstanceOf(Name::class, Name::fromString($string));
-        $this->assertSame((string) Name::fromString($string), $string);
+        $this->assertSame($string, (string) Name::fromString($string));
+    }
+
+    /**
+     * @test
+     * @covers ::__toString
+     */
+    public function it_should_be_treatable_as_a_string()
+    {
+        $string = 'sexy name';
+        $thing = (string)Name::fromString($string);
+
+        $this->assertSame($string, $thing);
     }
 }

--- a/test/unit/SectionField/ValueObject/PropertyNameTest.php
+++ b/test/unit/SectionField/ValueObject/PropertyNameTest.php
@@ -23,4 +23,23 @@ class PropertyNameTest extends TestCase
         $this->assertInstanceOf(PropertyName::class, $propertyName);
         $this->assertSame((string) $propertyName, 'aSexyCamel');
     }
+    /**
+     * @test
+     * @covers ::__toString
+     */
+    public function it_should_be_treatable_as_a_string()
+    {
+        $propertyNameString = (string)PropertyName::fromString('a sexy camel');
+        $this->assertSame('aSexyCamel', $propertyNameString);
+
+        $propertyNameString = (string)PropertyName::fromString('a-sexy-camel');
+        $this->assertSame('aSexyCamel', $propertyNameString);
+
+        $propertyNameString = (string)PropertyName::fromString('a_sexy_camel');
+        $this->assertSame('aSexyCamel', $propertyNameString);
+
+        $propertyNameString = (string)PropertyName::fromString('a.sexy.camel');
+        $this->assertSame('aSexyCamel', $propertyNameString);
+    }
+
 }

--- a/test/unit/SectionField/ValueObject/SearchTest.php
+++ b/test/unit/SectionField/ValueObject/SearchTest.php
@@ -21,6 +21,17 @@ class SearchTest extends TestCase
         $string = 'a sexy search';
         $search = Search::fromString($string);
         $this->assertInstanceOf(Search::class, $search);
-        $this->assertSame((string) $search, $string);
+        $this->assertSame($string, (string) $search);
+    }
+
+    /**
+     * @test
+     * @covers ::__toString
+     */
+    public function it_should_be_treatable_as_a_string()
+    {
+        $string = 'a sexy search';
+        $thing = (string)Search::fromString($string);
+        $this->assertSame($string, $thing);
     }
 }

--- a/test/unit/SectionField/ValueObject/SectionConfigTest.php
+++ b/test/unit/SectionField/ValueObject/SectionConfigTest.php
@@ -414,4 +414,37 @@ class SectionConfigTest extends TestCase
         $this->expectExceptionMessage('The namespace value should not be empty');
         SectionConfig::fromArray($sexyArray);
     }
+
+    /**
+     * @test
+     * @covers ::__toString
+     */
+    public function it_should_be_treatable_as_a_string()
+    {
+        $sexyConfigArray = [
+            'section' => [
+                'name' => 'sexyName',
+                'handle' => 'sexyHandles',
+                'fields' => [
+                    's' => 'e',
+                    'x' => 'y'
+                ],
+                'default' => 'Sexy per Default',
+                'namespace' => 'sexy space',
+                'generator' => 'Generator of awesome sexyness'
+            ]
+        ];
+
+        $expected = "name:sexyName\n"
+                  . "handle:sexyHandles\n"
+                  . "fields:\n"
+                  . "- s:e\n"
+                  . "- x:y\n"
+                  . "default:Sexy per Default\n"
+                  . "namespace:sexy space\n"
+                  . "generator:Generator of awesome sexyness\n";
+
+        $sexyConfigArrayString = (string)SectionConfig::fromArray($sexyConfigArray);
+        $this->assertEquals($expected, $sexyConfigArrayString);
+    }
 }

--- a/test/unit/SectionField/ValueObject/SectionNamespaceTest.php
+++ b/test/unit/SectionField/ValueObject/SectionNamespaceTest.php
@@ -20,4 +20,15 @@ class SectionNamespaceTest extends TestCase
     {
         $this->assertInstanceOf(SectionNamespace::class, SectionNamespace::fromString('sexy string'));
     }
+    /**
+     * @test
+     * @covers ::__toString
+     */
+    public function it_should_be_treatable_as_a_string()
+    {
+        $string = 'sexy string!';
+        $thing = (string)SectionNamespace::fromString($string);
+
+        $this->assertSame($string, $thing);
+    }
 }

--- a/test/unit/SectionField/ValueObject/SlugFieldTest.php
+++ b/test/unit/SectionField/ValueObject/SlugFieldTest.php
@@ -6,11 +6,11 @@ namespace Tardigrades\SectionField\ValueObject;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @coversDefaultClass Tardigrades\SectionField\ValueObject\UpdatedField
+ * @coversDefaultClass Tardigrades\SectionField\ValueObject\SlugField
  * @covers ::<private>
  * @covers ::__construct
  */
-class UpdatedFieldTest extends TestCase
+class SlugFieldTest extends TestCase
 {
     /**
      * @test
@@ -20,9 +20,10 @@ class UpdatedFieldTest extends TestCase
      */
     public function it_creates_from_string()
     {
-        $updatedField = UpdatedField::fromString('updated sexy field');
-        $this->assertInstanceOf(UpdatedField::class, $updatedField);
-        $this->assertSame('updated sexy field', (string) $updatedField);
+        $string = 'this and that';
+        $sexySnail = SlugField::fromString($string);
+        $this->assertInstanceOf(SlugField::class,$sexySnail);
+        $this->assertSame($string, (string) $sexySnail);
     }
 
     /**
@@ -30,10 +31,9 @@ class UpdatedFieldTest extends TestCase
      * @covers ::fromString
      * @covers ::__construct
      */
-    public function it_throws_exception_if_empty()
+    public function it_throws_exception_with_empty_string()
     {
         $this->expectException('InvalidArgumentException');
-        $this->expectExceptionMessage('Value is not specified');
-        UpdatedField::fromString('');
+        SlugField::fromString('');
     }
 }

--- a/test/unit/SectionField/ValueObject/SlugTest.php
+++ b/test/unit/SectionField/ValueObject/SlugTest.php
@@ -16,18 +16,20 @@ class SlugTest extends TestCase
      * @test
      * @covers ::fromString
      * @covers ::toArray
+     * @covers ::__toString
      */
     public function it_creates_from_string()
     {
         $sexySnail = Slug::fromString('this and that');
         $this->assertInstanceOf(Slug::class,$sexySnail);
-        $this->assertSame($sexySnail->toArray(), ['this and that']);
-        $this->assertSame((string) $sexySnail, 'this and that');
+        $this->assertSame(['this and that'], $sexySnail->toArray());
+        $this->assertSame('this and that', (string) $sexySnail);
     }
 
     /**
      * @test
      * @covers ::create
+     * @covers ::__toString
      */
     public function it_creates()
     {

--- a/test/unit/SectionField/ValueObject/SortTest.php
+++ b/test/unit/SectionField/ValueObject/SortTest.php
@@ -1,0 +1,60 @@
+<?php
+declare (strict_types=1);
+
+namespace Tardigrades\SectionField\ValueObject;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass Tardigrades\SectionField\ValueObject\Sort
+ * @covers ::<private>
+ * @covers ::__construct
+ */
+class SortTest extends TestCase
+{
+    /**
+     * @test
+     * @covers ::fromString
+     * @covers ::__construct
+     * @covers ::__toString
+     */
+    public function it_creates_from_string()
+    {
+        $sort = Sort::fromString('asc');
+        $this->assertInstanceOf(Sort::class, $sort);
+        $this->assertSame(Sort::ASC, (string)$sort);
+    }
+
+    /**
+     * @test
+     * @covers ::fromString
+     * @covers ::__construct
+     */
+    public function it_throws_exception_with_empty_string()
+    {
+        $this->expectException('InvalidArgumentException');
+        Sort::fromString('');
+    }
+
+    /**
+     * @test
+     * @covers ::fromString
+     * @covers ::__construct
+     */
+    public function it_throws_exception_with_invalid_string()
+    {
+        $this->expectException('InvalidArgumentException');
+        Sort::fromString('oops');
+    }
+
+    /**
+     * @test
+     * @covers ::fromString
+     * @covers ::__construct
+     */
+    public function it_throws_exception_with_capital_string()
+    {
+        $this->expectException('InvalidArgumentException');
+        Sort::fromString('ASC');
+    }
+}

--- a/test/unit/SectionField/ValueObject/TextTest.php
+++ b/test/unit/SectionField/ValueObject/TextTest.php
@@ -33,4 +33,15 @@ class TextTest extends TestCase
         $this->expectExceptionMessage('Value is not specified');
         Text::fromString('');
     }
+
+    /**
+     * @test
+     * @covers ::__toString
+     */
+    public function it_should_be_treatable_as_a_string()
+    {
+        $string = 'a sexy text';
+        $thing = (string)Text::fromString($string);
+        $this->assertSame($string, $thing);
+    }
 }

--- a/test/unit/SectionField/ValueObject/TypeTest.php
+++ b/test/unit/SectionField/ValueObject/TypeTest.php
@@ -14,6 +14,8 @@ class TypeTest extends TestCase
 {
     /**
      * @test
+     * @covers ::__construct
+     * @covers ::__toString
      * @covers ::fromString
      */
     public function it_creates_from_string()

--- a/test/unit/SectionField/ValueObject/UpdatedTest.php
+++ b/test/unit/SectionField/ValueObject/UpdatedTest.php
@@ -16,13 +16,14 @@ class UpdatedTest extends TestCase
      * @test
      * @covers ::fromDateTime
      * @covers ::getDateTime
+     * @covers ::__toString
      */
     public function it_should_create_from_DateTime()
     {
         $datetime = new \DateTime('2000-11-11T12:12:12');
         $updated = Updated::fromDateTime($datetime);
         $this->assertInstanceOf(Updated::class, $updated);
-        $this->assertEquals($updated->getDateTime(), new \DateTime('2000-11-11T12:12:12'));
-        $this->assertEquals((string)$updated, '2000-11-11T12:12');
+        $this->assertEquals(new \DateTime('2000-11-11T12:12:12'), $updated->getDateTime());
+        $this->assertEquals('2000-11-11T12:12', (string)$updated);
     }
 }

--- a/test/unit/SectionField/ValueObject/VersionTest.php
+++ b/test/unit/SectionField/ValueObject/VersionTest.php
@@ -16,11 +16,14 @@ class VersionTest extends TestCase
      * @test
      * @covers ::fromInt
      * @covers ::toInt
+     * @covers ::__construct
+     * @covers ::__toString
      */
     public function it_creates_from_int()
     {
         $sexyVersion = Version::fromInt(42);
         $this->assertInstanceOf(Version::class, $sexyVersion);
         $this->assertSame(42, $sexyVersion->toInt());
+        $this->assertSame('42', (string)$sexyVersion);
     }
 }

--- a/test/unit/SectionField/ValueObject/VersionedTest.php
+++ b/test/unit/SectionField/ValueObject/VersionedTest.php
@@ -16,13 +16,15 @@ class VersionedTest extends TestCase
      * @test
      * @covers ::fromDateTime
      * @covers ::getDateTime
+     * @covers ::__construct
+     * @covers ::__toString
      */
     public function it_should_create_from_DateTime()
     {
         $datetime = new \DateTime('2000-11-11T12:12:12');
         $versioned = Versioned::fromDateTime($datetime);
         $this->assertInstanceOf(Versioned::class, $versioned);
-        $this->assertEquals($versioned->getDateTime(), new \DateTime('2000-11-11T12:12:12'));
-        $this->assertEquals((string)$versioned, '2000-11-11T12:12');
+        $this->assertEquals(new \DateTime('2000-11-11T12:12:12'), $versioned->getDateTime());
+        $this->assertEquals('2000-11-11T12:12', (string)$versioned);
     }
 }


### PR DESCRIPTION
Wrote a test for the toString() method of all objects + added missing tests.
Also found - what I think was - a bug in `src/SectionField/ValueObject/GeneratorConfig.php`, so I fixed it.