### PR TITLE
Let getSection throw a SectionNotFoundException

### DIFF
--- a/src/Command/DeleteSectionCommand.php
+++ b/src/Command/DeleteSectionCommand.php
@@ -38,19 +38,19 @@ class DeleteSectionCommand extends SectionCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $sections = $this->sectionManager->readAll();
-        $this->renderTable($output, $sections, 'All installed Sections');
-        $this->deleteWhatRecord($input, $output);
+        try {
+            $sections = $this->sectionManager->readAll();
+            $this->renderTable($output, $sections, 'All installed Sections');
+            $this->deleteWhatRecord($input, $output);
+        } catch (SectionNotFoundException $exception) {
+            $output->writeln("Section not found.");
+        }
     }
 
     private function deleteWhatRecord(InputInterface $input, OutputInterface $output): void
     {
         /** @var SectionInterface $section */
         $section = $this->getSection($input, $output);
-
-        if (!$section) {
-            return;
-        }
 
         $output->writeln('<info>Record with id #' . $section->getId() . ' will be deleted</info>');
 

--- a/src/Command/GenerateSectionCommand.php
+++ b/src/Command/GenerateSectionCommand.php
@@ -20,6 +20,7 @@ use Tardigrades\SectionField\Generator\Writer\GeneratorFileWriter;
 use Tardigrades\SectionField\Generator\Writer\Writable;
 use Tardigrades\SectionField\Generator\GeneratorsInterface;
 use Tardigrades\SectionField\Service\SectionManagerInterface;
+use Tardigrades\SectionField\Service\SectionNotFoundException;
 
 class GenerateSectionCommand extends SectionCommand
 {
@@ -47,18 +48,18 @@ class GenerateSectionCommand extends SectionCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): void
     {
-        $sections = $this->sectionManager->readAll();
-        $this->renderTable($output, $sections, 'Available sections.');
-        $this->generateWhatSection($input, $output);
+        try {
+            $sections = $this->sectionManager->readAll();
+            $this->renderTable($output, $sections, 'Available sections.');
+            $this->generateWhatSection($input, $output);
+        } catch (SectionNotFoundException $exception) {
+            $output->writeln("Section not found.");
+        }
     }
 
     private function generateWhatSection(InputInterface $input, OutputInterface $output): void
     {
         $section = $this->getSection($input, $output);
-
-        if (!$section) {
-            return;
-        }
 
         $writables = $this->entityGenerator->generateBySection($section);
 

--- a/src/Command/RestoreSectionCommand.php
+++ b/src/Command/RestoreSectionCommand.php
@@ -52,7 +52,7 @@ class RestoreSectionCommand extends SectionCommand
             $this->renderTable($output, $sections, 'All installed Sections');
             $this->restoreWhatRecord($input, $output);
         } catch (SectionNotFoundException $exception) {
-            $output->writeln('No section found');
+            $output->writeln('Section not found.');
         }
     }
 
@@ -74,7 +74,7 @@ class RestoreSectionCommand extends SectionCommand
 
         $this->sectionManager->restoreFromHistory($sectionFromHistory);
 
-        $output->writeln('<info>Config Restored! Run the genereate-section command to finish rollback.</info>');
+        $output->writeln('<info>Config Restored! Run the generate-section command to finish rollback.</info>');
     }
 
     protected function getSectionFromHistory(InputInterface $input, OutputInterface $output): SectionInterface

--- a/src/Command/SectionCommand.php
+++ b/src/Command/SectionCommand.php
@@ -76,11 +76,15 @@ abstract class SectionCommand extends Command
             try {
                 return $this->sectionManager->read(Id::fromInt((int) $id));
             } catch (SectionNotFoundException $exception) {
-                $output->writeln('<error>' . $exception->getMessage() . '</error>');
+                // Exceptions thrown from here seemingly can't be caught, so signal with a return value instead
+                return null;
             }
-            return null;
         });
 
-        return $this->getHelper('question')->ask($input, $output, $question);
+        $section = $this->getHelper('question')->ask($input, $output, $question);
+        if (!$section) {
+            throw new SectionNotFoundException();
+        }
+        return $section;
     }
 }

--- a/src/Command/UpdateSectionCommand.php
+++ b/src/Command/UpdateSectionCommand.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Yaml\Yaml;
 use Tardigrades\SectionField\Service\SectionManagerInterface;
+use Tardigrades\SectionField\Service\SectionNotFoundException;
 use Tardigrades\SectionField\ValueObject\SectionConfig;
 
 class UpdateSectionCommand extends SectionCommand
@@ -42,10 +43,13 @@ class UpdateSectionCommand extends SectionCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): void
     {
-        $sections = $this->sectionManager->readAll();
-
-        $this->renderTable($output, $sections, 'All installed Sections');
-        $this->updateWhatRecord($input, $output);
+        try {
+            $sections = $this->sectionManager->readAll();
+            $this->renderTable($output, $sections, 'All installed Sections');
+            $this->updateWhatRecord($input, $output);
+        } catch (SectionNotFoundException $exception) {
+            $output->writeln("Section not found.");
+        }
     }
 
     private function updateWhatRecord(InputInterface $input, OutputInterface $output): void

--- a/test/unit/Command/DeleteSectionCommandTest.php
+++ b/test/unit/Command/DeleteSectionCommandTest.php
@@ -129,7 +129,7 @@ YML;
             ->shouldReceive('delete')
             ->never();
 
-        $commandTester->setInputs([1, 'y']);
+        $commandTester->setInputs([1]);
         $commandTester->execute(['command' => $command->getName()]);
 
         $this->assertRegExp(

--- a/test/unit/Command/GenerateSectionCommandTest.php
+++ b/test/unit/Command/GenerateSectionCommandTest.php
@@ -188,7 +188,7 @@ YML;
             ->shouldReceive('getBuildMessages')
             ->never();
 
-        $commandTester->setInputs([1, 'y']);
+        $commandTester->setInputs([1]);
         $commandTester->execute(['command' => $command->getName()]);
 
         $this->assertRegExp(

--- a/test/unit/Command/UpdateSectionCommandTest.php
+++ b/test/unit/Command/UpdateSectionCommandTest.php
@@ -183,17 +183,12 @@ YML;
         $commandTester->execute(
             [
                 'command' => $command->getName(),
-                'config' => $yml
+                'config' => $this->file
             ]
         );
 
         $this->assertRegExp(
             '/Section not found/',
-            $commandTester->getDisplay()
-        );
-
-        $this->assertRegExp(
-            '/Invalid configuration file/',
             $commandTester->getDisplay()
         );
     }


### PR DESCRIPTION
Lets `SectionCommand->getSection` throw a `SectionNotFoundException` instead of returning `null`. Resolves #46.
Exceptions thrown from inside the anonymous validator function didn't work, so now it still returns `null` but `getSection` throws a new `SectionNotFoundException`.