### PR TITLE
Add most missing command unit tests

### DIFF
--- a/src/Command/DeleteFieldTypeCommand.php
+++ b/src/Command/DeleteFieldTypeCommand.php
@@ -50,9 +50,13 @@ class DeleteFieldTypeCommand extends FieldTypeCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): void
     {
-        $this->questionHelper = $this->getHelper('question');
+        try {
+            $this->questionHelper = $this->getHelper('question');
 
-        $this->showInstalledFieldTypes($input, $output);
+            $this->showInstalledFieldTypes($input, $output);
+        } catch (FieldTypeNotFoundException $exception) {
+            $output->writeln("Field type not found");
+        }
     }
 
     private function showInstalledFieldTypes(InputInterface $input, OutputInterface $output): void
@@ -102,11 +106,14 @@ class DeleteFieldTypeCommand extends FieldTypeCommand
             try {
                 return $this->fieldTypeManager->read(Id::fromInt((int) $id));
             } catch (FieldTypeNotFoundException $exception) {
-                $output->writeln('<error>' . $exception->getMessage() . '</error>');
+                return null;
             }
-            return null;
         });
 
-        return $this->questionHelper->ask($input, $output, $question);
+        $fieldType = $this->questionHelper->ask($input, $output, $question);
+        if (!$fieldType) {
+            throw new FieldTypeNotFoundException();
+        }
+        return $fieldType;
     }
 }

--- a/src/Command/ListFieldTypeCommand.php
+++ b/src/Command/ListFieldTypeCommand.php
@@ -45,7 +45,7 @@ class ListFieldTypeCommand extends FieldTypeCommand
             $fieldTypes = $this->fieldTypeManager->readAll();
             $this->renderTable($output, $fieldTypes, 'All installed FieldTypes');
         } catch (FieldTypeNotFoundException $exception) {
-            $output->writeln('No FieldTypeInterface found');
+            $output->writeln('No FieldType found');
         }
     }
 }

--- a/src/Command/UpdateFieldCommand.php
+++ b/src/Command/UpdateFieldCommand.php
@@ -52,9 +52,13 @@ class UpdateFieldCommand extends FieldCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->questionHelper = $this->getHelper('question');
+        try {
+            $this->questionHelper = $this->getHelper('question');
 
-        $this->showInstalledFields($input, $output);
+            $this->showInstalledFields($input, $output);
+        } catch (FieldNotFoundException $exception) {
+            $output->writeln("Field not found");
+        }
     }
 
     private function showInstalledFields(InputInterface $input, OutputInterface $output): void
@@ -72,12 +76,15 @@ class UpdateFieldCommand extends FieldCommand
             try {
                 return $this->fieldManager->read(Id::fromInt((int) $id));
             } catch (FieldNotFoundException $exception) {
-                $output->writeln('<error>' . $exception->getMessage() . '</error>');
+                return null;
             }
-            return null;
         });
 
-        return $this->questionHelper->ask($input, $output, $question);
+        $field = $this->questionHelper->ask($input, $output, $question);
+        if (!$field) {
+            throw new FieldNotFoundException();
+        }
+        return $field;
     }
 
     private function updateWhatRecord(InputInterface $input, OutputInterface $output): void

--- a/test/unit/Command/DeleteSectionCommandTest.php
+++ b/test/unit/Command/DeleteSectionCommandTest.php
@@ -138,6 +138,51 @@ YML;
         );
     }
 
+    /**
+     * @test
+     * @covers ::configure
+     * @covers ::execute
+     */
+    public function it_should_not_delete_section_when_user_does_not_confirm()
+    {
+        $yml = <<<YML
+section:
+    name: foo
+    handle: bar
+    fields: []
+    default: Default
+    namespace: My\Namespace
+YML;
+
+        file_put_contents($this->file, $yml);
+
+        $command = $this->application->find('sf:delete-section');
+        $commandTester = new CommandTester($command);
+
+        $sections = $this->givenAnArrayOfSections();
+
+        $this->sectionManager
+            ->shouldReceive('readAll')
+            ->once()
+            ->andReturn($sections);
+
+        $this->sectionManager
+            ->shouldReceive('read')
+            ->once()
+            ->andReturn($sections[0]);
+
+        $this->sectionManager
+            ->shouldNotReceive('delete');
+
+        $commandTester->setInputs([1, 'n']);
+        $commandTester->execute(['command' => $command->getName()]);
+
+        $this->assertRegExp(
+            '/Cancelled/',
+            $commandTester->getDisplay()
+        );
+    }
+
     private function givenAnArrayOfSections()
     {
         return [

--- a/test/unit/Command/GenerateSectionCommandTest.php
+++ b/test/unit/Command/GenerateSectionCommandTest.php
@@ -197,6 +197,56 @@ YML;
         );
     }
 
+    /**
+     * @test
+     * @covers ::configure
+     * @covers ::execute
+     */
+    public function it_should_not_generate_a_section_when_user_does_not_confirm()
+    {
+        $yml = <<<YML
+section:
+    name: foo
+    handle: bar
+    fields: []
+    default: Default
+    namespace: My\Namespace
+YML;
+
+        file_put_contents($this->file, $yml);
+
+        $command = $this->application->find('sf:generate-section');
+        $commandTester = new CommandTester($command);
+
+        $sections = $this->givenAnArrayOfSections();
+
+        $this->sectionManager
+            ->shouldReceive('readAll')
+            ->once()
+            ->andReturn($sections);
+
+        $this->sectionManager
+            ->shouldReceive('read')
+            ->once()
+            ->andReturn($sections[0]);
+
+        $this->entityGenerator
+            ->shouldReceive('generateBySection')
+            ->with($sections[0])
+            ->once();
+
+        $this->entityGenerator
+            ->shouldNotReceive('getBuildMessages');
+
+        $commandTester->setInputs([1, 'n']);
+        $commandTester->execute(['command' => $command->getName()]);
+
+        $this->assertRegExp(
+            '/Cancelled/',
+            $commandTester->getDisplay()
+        );
+    }
+
     private function givenAnArrayOfSections()
     {
         return [

--- a/test/unit/Command/ListApplicationCommandTest.php
+++ b/test/unit/Command/ListApplicationCommandTest.php
@@ -12,6 +12,7 @@ use Tardigrades\Entity\Language;
 use Tardigrades\Entity\Section;
 use Tardigrades\SectionField\Service\ApplicationManagerInterface;
 use Tardigrades\Entity\Application as ApplicationEntity;
+use Tardigrades\SectionField\Service\ApplicationNotFoundException;
 
 /**
  * @coversDefaultClass Tardigrades\Command\ListApplicationCommand
@@ -135,6 +136,29 @@ final class ListApplicationCommandTest extends TestCase
 
         $this->assertRegExp(
             '/Another Super section name/',
+            $commandTester->getDisplay()
+        );
+    }
+
+    /**
+     * @test
+     * @covers ::configure
+     * @covers ::execute
+     */
+    public function it_should_fail_without_applications()
+    {
+        $command = $this->application->find('sf:list-application');
+        $commandTester = new CommandTester($command);
+
+        $this->applicationManager
+            ->shouldReceive('readAll')
+            ->once()
+            ->andThrow(ApplicationNotFoundException::class);
+
+        $commandTester->execute(['command' => $command->getName()]);
+
+        $this->assertRegExp(
+            '/No applications found/',
             $commandTester->getDisplay()
         );
     }

--- a/test/unit/Command/ListFieldCommandTest.php
+++ b/test/unit/Command/ListFieldCommandTest.php
@@ -13,6 +13,7 @@ use Symfony\Component\Yaml\Yaml;
 use Tardigrades\Entity\Field;
 use Tardigrades\Entity\FieldType;
 use Tardigrades\SectionField\Service\FieldManagerInterface;
+use Tardigrades\SectionField\Service\FieldNotFoundException;
 
 /**
  * @coversDefaultClass Tardigrades\Command\ListFieldCommand
@@ -115,6 +116,29 @@ YML;
 
         $this->assertRegExp(
             '/All installed Fields/',
+            $commandTester->getDisplay()
+        );
+    }
+
+    /**
+     * @test
+     * @covers ::configure
+     * @covers ::execute
+     */
+    public function it_should_fail_without_fields()
+    {
+        $command = $this->application->find('sf:list-field');
+        $commandTester = new CommandTester($command);
+
+        $this->fieldManager
+            ->shouldReceive('readAll')
+            ->once()
+            ->andThrow(FieldNotFoundException::class);
+
+        $commandTester->execute(['command' => $command->getName()]);
+
+        $this->assertRegExp(
+            '/No fields found/',
             $commandTester->getDisplay()
         );
     }

--- a/test/unit/Command/ListFieldTypeCommandTest.php
+++ b/test/unit/Command/ListFieldTypeCommandTest.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Tardigrades\Entity\FieldType;
 use Tardigrades\SectionField\Service\FieldTypeManagerInterface;
+use Tardigrades\SectionField\Service\FieldTypeNotFoundException;
 
 /**
  * @coversDefaultClass Tardigrades\Command\ListFieldTypeCommand
@@ -100,6 +101,29 @@ final class ListFieldTypeCommandTest extends TestCase
 
         $this->assertRegExp(
             '/All installed FieldTypes/',
+            $commandTester->getDisplay()
+        );
+    }
+
+    /**
+     * @test
+     * @covers ::configure
+     * @covers ::execute
+     */
+    public function it_should_fail_without_field_types()
+    {
+        $command = $this->application->find('sf:list-field-type');
+        $commandTester = new CommandTester($command);
+
+        $this->fieldTypeManager
+            ->shouldReceive('readAll')
+            ->once()
+            ->andThrow(FieldTypeNotFoundException::class);
+
+        $commandTester->execute(['command' => $command->getName()]);
+
+        $this->assertRegExp(
+            '/No FieldType found/',
             $commandTester->getDisplay()
         );
     }

--- a/test/unit/Command/ListLanguageCommandTest.php
+++ b/test/unit/Command/ListLanguageCommandTest.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Tardigrades\Entity\Language;
 use Tardigrades\SectionField\Service\LanguageManagerInterface;
 use Tardigrades\Entity\Application as ApplicationEntity;
+use Tardigrades\SectionField\Service\LanguageNotFoundException;
 
 /**
  * @coversDefaultClass Tardigrades\Command\ListLanguageCommand
@@ -77,7 +78,7 @@ final class ListLanguageCommandTest extends TestCase
      * @covers ::configure
      * @covers ::execute
      */
-    public function it_should_list_field_types()
+    public function it_should_list_languages()
     {
         $command = $this->application->find('sf:list-language');
         $commandTester = new CommandTester($command);
@@ -123,6 +124,29 @@ final class ListLanguageCommandTest extends TestCase
 
         $this->assertRegExp(
             '/Fffff, name/',
+            $commandTester->getDisplay()
+        );
+    }
+
+    /**
+     * @test
+     * @covers ::configure
+     * @covers ::execute
+     */
+    public function it_should_fail_without_languages()
+    {
+        $command = $this->application->find('sf:list-language');
+        $commandTester = new CommandTester($command);
+
+        $this->languageManager
+            ->shouldReceive('readAll')
+            ->once()
+            ->andThrow(LanguageNotFoundException::class);
+
+        $commandTester->execute(['command' => $command->getName()]);
+
+        $this->assertRegExp(
+            '/No language found/',
             $commandTester->getDisplay()
         );
     }

--- a/test/unit/Command/ListSectionCommandTest.php
+++ b/test/unit/Command/ListSectionCommandTest.php
@@ -11,6 +11,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Yaml\Yaml;
 use Tardigrades\Entity\Section;
 use Tardigrades\SectionField\Service\SectionManagerInterface;
+use Tardigrades\SectionField\Service\SectionNotFoundException;
 
 /**
  * @coversDefaultClass Tardigrades\Command\ListSectionCommand
@@ -63,12 +64,12 @@ YML;
         $command = $this->application->find('sf:list-section');
         $commandTester = new CommandTester($command);
 
-        $languages = $this->givenAnArrayOfSections();
+        $sections = $this->givenAnArrayOfSections();
 
         $this->sectionManager
             ->shouldReceive('readAll')
             ->once()
-            ->andReturn($languages);
+            ->andReturn($sections);
 
         $commandTester->execute(['command' => $command->getName()]);
 
@@ -128,6 +129,29 @@ YML;
 
         $this->assertRegExp(
             '/All installed Sections/',
+            $commandTester->getDisplay()
+        );
+    }
+
+    /**
+     * @test
+     * @covers ::configure
+     * @covers ::execute
+     */
+    public function it_should_fail_without_sections()
+    {
+        $command = $this->application->find('sf:list-section');
+        $commandTester = new CommandTester($command);
+
+        $this->sectionManager
+            ->shouldReceive('readAll')
+            ->once()
+            ->andThrow(SectionNotFoundException::class);
+
+        $commandTester->execute(['command' => $command->getName()]);
+
+        $this->assertRegExp(
+            '/No section found/',
             $commandTester->getDisplay()
         );
     }

--- a/test/unit/Command/RestoreSectionCommandTest.php
+++ b/test/unit/Command/RestoreSectionCommandTest.php
@@ -198,6 +198,53 @@ YML;
         );
     }
 
+    /**
+     * @test
+     * @covers ::configure
+     * @covers ::execute
+     */
+    public function it_should_not_restore_a_section_when_user_does_not_confirm()
+    {
+        $yml = <<<YML
+section:
+    name: foo
+    handle: bar
+    fields: []
+    default: Default
+    namespace: My\Namespace
+YML;
+
+        file_put_contents($this->file, $yml);
+
+        $command = $this->application->find('sf:restore-section');
+        $commandTester = new CommandTester($command);
+
+        $this->sectionManager
+            ->shouldReceive('readAll')
+            ->once()
+            ->andReturn($this->givenAnArrayOfSections());
+
+        $this->sectionManager
+            ->shouldReceive('read')
+            ->once()
+            ->andReturn($this->givenAnArrayOfSections()[0]);
+
+        $this->sectionHistoryManager
+            ->shouldReceive('read')
+            ->once()
+            ->andReturn($this->givenAnOldSection());
+
+        $this->sectionManager
+            ->shouldNotReceive('restoreFromHistory');
+
+        $commandTester->setInputs([1, 1, 'n']);
+        $commandTester->execute(['command' => $command->getName()]);
+        $this->assertRegExp(
+            '/Cancelled/',
+            $commandTester->getDisplay()
+        );
+    }
+
     private function givenAnArrayOfSections()
     {
         return [

--- a/test/unit/Command/RestoreSectionCommandTest.php
+++ b/test/unit/Command/RestoreSectionCommandTest.php
@@ -1,0 +1,247 @@
+<?php
+declare (strict_types=1);
+
+namespace Tardigrades\Command;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Yaml\Yaml;
+use Tardigrades\Entity\Section;
+use Tardigrades\SectionField\Service\SectionHistoryManagerInterface;
+use Tardigrades\SectionField\Service\SectionHistoryNotFoundException;
+use Tardigrades\SectionField\Service\SectionManagerInterface;
+use Tardigrades\SectionField\Service\SectionNotFoundException;
+
+/**
+ * @coversDefaultClass Tardigrades\Command\RestoreSectionCommand
+ * @covers ::<private>
+ * @covers ::<protected>
+ * @covers ::__construct
+ */
+final class RestoreSectionCommandTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /** @var SectionManagerInterface */
+    private $sectionManager;
+
+    /** @var SectionHistoryManagerInterface */
+    private $sectionHistoryManager;
+
+    /** @var RestoreSectionCommand */
+    private $restoreSectionCommand;
+
+    /** @var Application */
+    private $application;
+
+    /** @var vfsStream */
+    private $file;
+
+    public function setUp()
+    {
+        vfsStream::setup('home');
+        $this->file = vfsStream::url('home/some-config-file.yml');
+        $this->sectionManager = Mockery::mock(SectionManagerInterface::class);
+        $this->sectionHistoryManager = Mockery::mock(SectionHistoryManagerInterface::class);
+        $this->restoreSectionCommand = new RestoreSectionCommand($this->sectionManager, $this->sectionHistoryManager);
+        $this->application = new Application();
+        $this->application->add($this->restoreSectionCommand);
+    }
+
+    /**
+     * @test
+     * @covers ::configure
+     * @covers ::execute
+     */
+    public function it_should_restore_a_section()
+    {
+        $yml = <<<YML
+section:
+    name: foo
+    handle: bar
+    fields: []
+    default: Default
+    namespace: My\Namespace
+YML;
+
+        file_put_contents($this->file, $yml);
+
+        $command = $this->application->find('sf:restore-section');
+        $commandTester = new CommandTester($command);
+
+        $this->sectionManager
+            ->shouldReceive('readAll')
+            ->once()
+            ->andReturn($this->givenAnArrayOfSections());
+
+        $this->sectionManager
+            ->shouldReceive('read')
+            ->once()
+            ->andReturn($this->givenAnArrayOfSections()[0]);
+
+        $this->sectionHistoryManager
+            ->shouldReceive('read')
+            ->once()
+            ->andReturn($this->givenAnOldSection());
+
+        $this->sectionManager
+            ->shouldReceive('restoreFromHistory')
+            ->once()
+            ->andReturn($this->givenAnUpdatedSection());
+
+        $commandTester->setInputs([1, 1, 'y']);
+        $commandTester->execute(['command' => $command->getName()]);
+        $this->assertRegExp(
+            '/Config Restored!/',
+            $commandTester->getDisplay()
+        );
+    }
+
+    /**
+     * @test
+     * @covers ::configure
+     * @covers ::execute
+     */
+    public function it_should_fail_on_non_existing_section()
+    {
+        $yml = <<<YML
+section:
+    name: foo
+    handle: bar
+    fields: []
+    default: Default
+    namespace: My\Namespace
+YML;
+
+        file_put_contents($this->file, $yml);
+
+        $command = $this->application->find('sf:restore-section');
+        $commandTester = new CommandTester($command);
+
+        $this->sectionManager
+            ->shouldReceive('readAll')
+            ->once()
+            ->andReturn($this->givenAnArrayOfSections());
+
+        $this->sectionManager
+            ->shouldReceive('read')
+            ->once()
+            ->andThrow(SectionNotFoundException::class);
+
+        $this->sectionHistoryManager
+            ->shouldReceive('read')
+            ->never();
+
+        $this->sectionManager
+            ->shouldReceive('restoreFromHistory')
+            ->never();
+
+        $commandTester->setInputs([5]);
+        $commandTester->execute(['command' => $command->getName()]);
+
+        $this->assertRegExp(
+            '/Section not found/',
+            $commandTester->getDisplay()
+        );
+    }
+
+    /**
+     * @test
+     * @covers ::configure
+     * @covers ::execute
+     */
+    public function it_should_fail_on_non_existing_version()
+    {
+        $yml = <<<YML
+section:
+    name: foo
+    handle: bar
+    fields: []
+    default: Default
+    namespace: My\Namespace
+YML;
+
+        file_put_contents($this->file, $yml);
+
+        $command = $this->application->find('sf:restore-section');
+        $commandTester = new CommandTester($command);
+
+        $this->sectionManager
+            ->shouldReceive('readAll')
+            ->once()
+            ->andReturn($this->givenAnArrayOfSections());
+
+        $this->sectionManager
+            ->shouldReceive('read')
+            ->once()
+            ->andReturn($this->givenAnArrayOfSections()[0]);
+
+        $this->sectionHistoryManager
+            ->shouldReceive('read')
+            ->once()
+            ->andThrow(SectionHistoryNotFoundException::class);
+
+        $this->sectionManager
+            ->shouldReceive('restoreFromHistory')
+            ->never();
+
+        $commandTester->setInputs([1, 1]);
+        $commandTester->execute(['command' => $command->getName()]);
+
+        $this->assertRegExp(
+            '/Section history not found/',
+            $commandTester->getDisplay()
+        );
+    }
+
+    private function givenAnArrayOfSections()
+    {
+        return [
+            (new Section())
+                ->setName('Some name')
+                ->setHandle('someHandle')
+                ->setConfig(
+                    Yaml::parse(
+                        file_get_contents($this->file)
+                    )
+                )
+                ->setCreated(new \DateTime())
+                ->setUpdated(new \DateTime())
+                ->setVersion(2)
+        ];
+    }
+
+    private function givenAnOldSection()
+    {
+        return (new Section())
+            ->setName('Some name')
+            ->setHandle('someHandle')
+            ->setConfig(
+                Yaml::parse(
+                    file_get_contents($this->file)
+                )
+            )
+            ->setCreated(new \DateTime())
+            ->setUpdated(new \DateTime())
+            ->setVersion(1);
+    }
+
+    private function givenAnUpdatedSection()
+    {
+        return (new Section())
+            ->setName('Some name')
+            ->setHandle('someHandle')
+            ->setConfig(
+                Yaml::parse(
+                    file_get_contents($this->file)
+                )
+            )
+            ->setCreated(new \DateTime())
+            ->setUpdated(new \DateTime())
+            ->setVersion(3);
+    }
+}

--- a/test/unit/Command/UpdateApplicationCommandTest.php
+++ b/test/unit/Command/UpdateApplicationCommandTest.php
@@ -13,6 +13,8 @@ use Tardigrades\Entity\Language;
 use Tardigrades\Entity\Section;
 use Tardigrades\SectionField\Service\ApplicationManagerInterface;
 use Tardigrades\Entity\Application as ApplicationEntity;
+use Tardigrades\SectionField\Service\ApplicationNotFoundException;
+use Tardigrades\SectionField\Service\SectionNotFoundException;
 
 /**
  * @coversDefaultClass Tardigrades\Command\UpdateApplicationCommand
@@ -123,6 +125,40 @@ YML;
 
         $this->assertRegExp(
             '/Invalid configuration/',
+            $commandTester->getDisplay()
+        );
+    }
+
+    /**
+     * @test
+     * @covers ::configure
+     * @covers ::execute
+     */
+    public function it_should_fail_with_invalid_section()
+    {
+        $command = $this->application->find('sf:update-application');
+        $commandTester = new CommandTester($command);
+
+        $this->applicationManager
+            ->shouldReceive('readAll')
+            ->once()
+            ->andReturn($this->givenAnArrayOfApplications());
+
+        $this->applicationManager
+            ->shouldReceive('read')
+            ->once()
+            ->andThrow(ApplicationNotFoundException::class);
+
+        $commandTester->setInputs([10]);
+        $commandTester->execute(
+            [
+                'command' => $command->getName(),
+                'config' => $this->file
+            ]
+        );
+
+        $this->assertRegExp(
+            '/Section not found/',
             $commandTester->getDisplay()
         );
     }

--- a/test/unit/Command/UpdateFieldTypeCommandTest.php
+++ b/test/unit/Command/UpdateFieldTypeCommandTest.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Tardigrades\Entity\FieldType;
 use Tardigrades\SectionField\Service\FieldTypeManagerInterface;
+use Tardigrades\SectionField\Service\FieldTypeNotFoundException;
 
 /**
  * @coversDefaultClass Tardigrades\Command\UpdateFieldTypeCommand
@@ -88,6 +89,35 @@ final class UpdateFieldTypeCommandTest extends TestCase
 
         $this->assertRegExp(
             '/FieldTypeInterface Updated!/',
+            $commandTester->getDisplay()
+        );
+    }
+
+    /**
+     * @test
+     * @covers ::configure
+     * @covers ::execute
+     */
+    public function it_should_fail_with_invalid_field_type()
+    {
+        $command = $this->application->find('sf:update-field-type');
+        $commandTester = new CommandTester($command);
+
+        $this->fieldTypeManager
+            ->shouldReceive('readAll')
+            ->once()
+            ->andReturn($this->givenAnArrayOfFieldTypes());
+
+        $this->fieldTypeManager
+            ->shouldReceive('read')
+            ->once()
+            ->andThrow(FieldTypeNotFoundException::class);
+
+        $commandTester->setInputs([10]);
+        $commandTester->execute(['command' => $command->getName(),]);
+
+        $this->assertRegExp(
+            '/Field type not found/',
             $commandTester->getDisplay()
         );
     }

--- a/test/unit/Command/UpdateFieldTypeCommandTest.php
+++ b/test/unit/Command/UpdateFieldTypeCommandTest.php
@@ -93,6 +93,39 @@ final class UpdateFieldTypeCommandTest extends TestCase
         );
     }
 
+
+    /**
+     * @test
+     * @covers ::configure
+     * @covers ::execute
+     */
+    public function it_should_not_update_a_field_type_when_user_does_not_confirm()
+    {
+        $command = $this->application->find('sf:update-field-type');
+        $commandTester = new CommandTester($command);
+
+        $this->fieldTypeManager
+            ->shouldReceive('readAll')
+            ->once()
+            ->andReturn($this->givenAnArrayOfFieldTypes());
+
+        $this->fieldTypeManager
+            ->shouldReceive('read')
+            ->once()
+            ->andReturn($this->givenAnArrayOfFieldTypes()[0]);
+
+        $this->fieldTypeManager
+            ->shouldNotReceive('update');
+
+        $commandTester->setInputs([1, 'Totally\\New\\Fully\\Qualified\\Class\\Name', 'n']);
+        $commandTester->execute(['command' => $command->getName()]);
+
+        $this->assertRegExp(
+            '/Cancelled/',
+            $commandTester->getDisplay()
+        );
+    }
+
     /**
      * @test
      * @covers ::configure


### PR DESCRIPTION
This adds most missing unit tests in `Command`, and changes exception handling in a few anonymous validator functions as in #47.