### PR TITLE
Updated update section command with auto-update flags

### DIFF
--- a/build/logs/clover.xml
+++ b/build/logs/clover.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1518705913">
-  <project timestamp="1518705913">
+<coverage generated="1518774701">
+  <project timestamp="1518774701">
     <package name="Tardigrades\Command">
       <file name="/Users/Dion/www/sexy-field/sexy-field/src/Command/ApplicationCommand.php">
         <class name="ApplicationCommand" namespace="Tardigrades\Command">
@@ -646,39 +646,39 @@
         <class name="SectionCommand" namespace="Tardigrades\Command">
           <metrics complexity="9" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="25" coveredstatements="25" elements="29" coveredelements="29"/>
         </class>
-        <line num="33" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="18"/>
-        <line num="37" type="stmt" count="18"/>
-        <line num="39" type="stmt" count="18"/>
-        <line num="40" type="stmt" count="18"/>
-        <line num="42" type="method" name="renderTable" visibility="protected" complexity="2" crap="2" count="14"/>
-        <line num="44" type="stmt" count="14"/>
-        <line num="46" type="stmt" count="14"/>
-        <line num="48" type="stmt" count="14"/>
-        <line num="49" type="stmt" count="14"/>
-        <line num="50" type="stmt" count="14"/>
-        <line num="51" type="stmt" count="14"/>
-        <line num="52" type="stmt" count="14"/>
-        <line num="53" type="stmt" count="14"/>
-        <line num="54" type="stmt" count="14"/>
-        <line num="55" type="stmt" count="14"/>
-        <line num="59" type="stmt" count="14"/>
-        <line num="60" type="stmt" count="14"/>
-        <line num="61" type="stmt" count="14"/>
-        <line num="65" type="stmt" count="14"/>
-        <line num="66" type="stmt" count="14"/>
-        <line num="68" type="stmt" count="14"/>
-        <line num="69" type="stmt" count="14"/>
-        <line num="71" type="method" name="getSection" visibility="protected" complexity="4" crap="4" count="13"/>
-        <line num="73" type="stmt" count="13"/>
-        <line num="75" type="method" name="anonymous function" complexity="2" crap="2" count="13"/>
-        <line num="77" type="stmt" count="13"/>
+        <line num="33" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="21"/>
+        <line num="37" type="stmt" count="21"/>
+        <line num="39" type="stmt" count="21"/>
+        <line num="40" type="stmt" count="21"/>
+        <line num="42" type="method" name="renderTable" visibility="protected" complexity="2" crap="2" count="15"/>
+        <line num="44" type="stmt" count="15"/>
+        <line num="46" type="stmt" count="15"/>
+        <line num="48" type="stmt" count="15"/>
+        <line num="49" type="stmt" count="15"/>
+        <line num="50" type="stmt" count="15"/>
+        <line num="51" type="stmt" count="15"/>
+        <line num="52" type="stmt" count="15"/>
+        <line num="53" type="stmt" count="15"/>
+        <line num="54" type="stmt" count="15"/>
+        <line num="55" type="stmt" count="15"/>
+        <line num="59" type="stmt" count="15"/>
+        <line num="60" type="stmt" count="15"/>
+        <line num="61" type="stmt" count="15"/>
+        <line num="65" type="stmt" count="15"/>
+        <line num="66" type="stmt" count="15"/>
+        <line num="68" type="stmt" count="15"/>
+        <line num="69" type="stmt" count="15"/>
+        <line num="71" type="method" name="getSection" visibility="protected" complexity="4" crap="4" count="12"/>
+        <line num="73" type="stmt" count="12"/>
+        <line num="75" type="method" name="anonymous function" complexity="2" crap="2" count="12"/>
+        <line num="77" type="stmt" count="12"/>
         <line num="78" type="stmt" count="4"/>
         <line num="80" type="stmt" count="4"/>
-        <line num="82" type="stmt" count="13"/>
-        <line num="84" type="stmt" count="13"/>
-        <line num="85" type="stmt" count="13"/>
+        <line num="82" type="stmt" count="12"/>
+        <line num="84" type="stmt" count="12"/>
+        <line num="85" type="stmt" count="12"/>
         <line num="86" type="stmt" count="4"/>
-        <line num="88" type="stmt" count="9"/>
+        <line num="88" type="stmt" count="8"/>
         <metrics loc="90" ncloc="78" classes="1" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="29" coveredstatements="29" elements="33" coveredelements="33"/>
       </file>
       <file name="/Users/Dion/www/sexy-field/sexy-field/src/Command/UpdateApplicationCommand.php">
@@ -750,60 +750,60 @@
         <line num="59" type="stmt" count="5"/>
         <line num="61" type="method" name="execute" visibility="protected" complexity="2" crap="2" count="5"/>
         <line num="64" type="stmt" count="5"/>
-        <line num="66" type="stmt" count="5"/>
+        <line num="65" type="stmt" count="5"/>
+        <line num="66" type="stmt" count="1"/>
         <line num="67" type="stmt" count="1"/>
-        <line num="68" type="stmt" count="1"/>
-        <line num="70" type="stmt" count="5"/>
-        <line num="72" type="method" name="showInstalledFields" visibility="private" complexity="2" crap="2" count="5"/>
-        <line num="74" type="stmt" count="5"/>
-        <line num="75" type="stmt" count="4"/>
-        <line num="77" type="stmt" count="5"/>
-        <line num="78" type="stmt" count="4"/>
-        <line num="80" type="method" name="getField" visibility="private" complexity="3" crap="3" count="2"/>
-        <line num="82" type="stmt" count="2"/>
-        <line num="83" type="method" name="anonymous function" complexity="2" crap="2" count="2"/>
-        <line num="85" type="stmt" count="2"/>
+        <line num="69" type="stmt" count="5"/>
+        <line num="71" type="method" name="showInstalledFields" visibility="private" complexity="2" crap="2" count="5"/>
+        <line num="73" type="stmt" count="5"/>
+        <line num="74" type="stmt" count="4"/>
+        <line num="76" type="stmt" count="5"/>
+        <line num="77" type="stmt" count="4"/>
+        <line num="79" type="method" name="getField" visibility="private" complexity="3" crap="3" count="2"/>
+        <line num="81" type="stmt" count="2"/>
+        <line num="82" type="method" name="anonymous function" complexity="2" crap="2" count="2"/>
+        <line num="84" type="stmt" count="2"/>
+        <line num="85" type="stmt" count="1"/>
         <line num="86" type="stmt" count="1"/>
-        <line num="87" type="stmt" count="1"/>
-        <line num="89" type="stmt" count="2"/>
+        <line num="88" type="stmt" count="2"/>
+        <line num="90" type="stmt" count="2"/>
         <line num="91" type="stmt" count="2"/>
-        <line num="92" type="stmt" count="2"/>
-        <line num="93" type="stmt" count="1"/>
-        <line num="95" type="stmt" count="1"/>
-        <line num="98" type="method" name="updateWhatRecord" visibility="private" complexity="7" crap="7.04" count="5"/>
-        <line num="100" type="stmt" count="5"/>
+        <line num="92" type="stmt" count="1"/>
+        <line num="94" type="stmt" count="1"/>
+        <line num="97" type="method" name="updateWhatRecord" visibility="private" complexity="7" crap="7.04" count="5"/>
+        <line num="99" type="stmt" count="5"/>
+        <line num="102" type="stmt" count="5"/>
         <line num="103" type="stmt" count="5"/>
         <line num="104" type="stmt" count="5"/>
-        <line num="105" type="stmt" count="5"/>
+        <line num="107" type="stmt" count="1"/>
         <line num="108" type="stmt" count="1"/>
         <line num="109" type="stmt" count="1"/>
-        <line num="110" type="stmt" count="1"/>
-        <line num="114" type="stmt" count="4"/>
-        <line num="116" type="stmt" count="2"/>
+        <line num="113" type="stmt" count="4"/>
+        <line num="115" type="stmt" count="2"/>
+        <line num="116" type="stmt" count="1"/>
         <line num="117" type="stmt" count="1"/>
         <line num="118" type="stmt" count="1"/>
-        <line num="119" type="stmt" count="1"/>
-        <line num="122" type="stmt" count="1"/>
-        <line num="123" type="stmt" count="0"/>
-        <line num="124" type="stmt" count="2"/>
+        <line num="121" type="stmt" count="1"/>
+        <line num="122" type="stmt" count="0"/>
+        <line num="123" type="stmt" count="2"/>
+        <line num="126" type="stmt" count="2"/>
         <line num="127" type="stmt" count="2"/>
         <line num="128" type="stmt" count="2"/>
         <line num="129" type="stmt" count="2"/>
         <line num="130" type="stmt" count="2"/>
-        <line num="131" type="stmt" count="2"/>
+        <line num="133" type="stmt" count="2"/>
         <line num="134" type="stmt" count="2"/>
         <line num="135" type="stmt" count="2"/>
-        <line num="136" type="stmt" count="2"/>
-        <line num="139" type="stmt" count="2"/>
+        <line num="138" type="stmt" count="2"/>
+        <line num="139" type="stmt" count="0"/>
         <line num="140" type="stmt" count="0"/>
-        <line num="141" type="stmt" count="0"/>
-        <line num="144" type="stmt" count="2"/>
+        <line num="143" type="stmt" count="2"/>
+        <line num="146" type="stmt" count="3"/>
         <line num="147" type="stmt" count="3"/>
-        <line num="148" type="stmt" count="3"/>
-        <line num="149" type="stmt" count="2"/>
-        <line num="151" type="stmt" count="1"/>
-        <line num="153" type="stmt" count="3"/>
-        <metrics loc="154" ncloc="144" classes="1" methods="7" coveredmethods="6" conditionals="0" coveredconditionals="0" statements="62" coveredstatements="59" elements="69" coveredelements="65"/>
+        <line num="148" type="stmt" count="2"/>
+        <line num="150" type="stmt" count="1"/>
+        <line num="152" type="stmt" count="3"/>
+        <metrics loc="153" ncloc="143" classes="1" methods="7" coveredmethods="6" conditionals="0" coveredconditionals="0" statements="62" coveredstatements="59" elements="69" coveredelements="65"/>
       </file>
       <file name="/Users/Dion/www/sexy-field/sexy-field/src/Command/UpdateFieldTypeCommand.php">
         <class name="UpdateFieldTypeCommand" namespace="Tardigrades\Command">
@@ -898,43 +898,92 @@
       </file>
       <file name="/Users/Dion/www/sexy-field/sexy-field/src/Command/UpdateSectionCommand.php">
         <class name="UpdateSectionCommand" namespace="Tardigrades\Command">
-          <metrics complexity="6" methods="4" coveredmethods="3" conditionals="0" coveredconditionals="0" statements="30" coveredstatements="28" elements="34" coveredelements="31"/>
+          <metrics complexity="20" methods="6" coveredmethods="5" conditionals="0" coveredconditionals="0" statements="77" coveredstatements="72" elements="83" coveredelements="77"/>
         </class>
-        <line num="27" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="3"/>
-        <line num="30" type="stmt" count="3"/>
-        <line num="31" type="stmt" count="3"/>
-        <line num="33" type="method" name="configure" visibility="protected" complexity="1" crap="1" count="3"/>
-        <line num="37" type="stmt" count="3"/>
-        <line num="38" type="stmt" count="3"/>
-        <line num="39" type="stmt" count="3"/>
-        <line num="42" type="stmt" count="3"/>
-        <line num="44" type="method" name="execute" visibility="protected" complexity="2" crap="2" count="3"/>
-        <line num="47" type="stmt" count="3"/>
-        <line num="48" type="stmt" count="3"/>
-        <line num="49" type="stmt" count="3"/>
-        <line num="50" type="stmt" count="1"/>
-        <line num="51" type="stmt" count="1"/>
-        <line num="53" type="stmt" count="3"/>
-        <line num="55" type="method" name="updateWhatRecord" visibility="private" complexity="2" crap="2.01" count="3"/>
-        <line num="57" type="stmt" count="3"/>
-        <line num="58" type="stmt" count="2"/>
-        <line num="61" type="stmt" count="2"/>
-        <line num="62" type="stmt" count="2"/>
-        <line num="63" type="stmt" count="2"/>
-        <line num="67" type="stmt" count="1"/>
-        <line num="68" type="stmt" count="0"/>
-        <line num="69" type="stmt" count="0"/>
-        <line num="70" type="stmt" count="1"/>
-        <line num="71" type="stmt" count="1"/>
-        <line num="72" type="stmt" count="1"/>
-        <line num="76" type="stmt" count="1"/>
-        <line num="77" type="stmt" count="1"/>
-        <line num="78" type="stmt" count="1"/>
-        <line num="79" type="stmt" count="1"/>
-        <line num="82" type="stmt" count="1"/>
-        <line num="83" type="stmt" count="1"/>
-        <line num="84" type="stmt" count="1"/>
-        <metrics loc="85" ncloc="73" classes="1" methods="4" coveredmethods="3" conditionals="0" coveredconditionals="0" statements="30" coveredstatements="28" elements="34" coveredelements="31"/>
+        <line num="32" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="6"/>
+        <line num="35" type="stmt" count="6"/>
+        <line num="36" type="stmt" count="6"/>
+        <line num="38" type="method" name="configure" visibility="protected" complexity="1" crap="1" count="6"/>
+        <line num="42" type="stmt" count="6"/>
+        <line num="44" type="stmt" count="6"/>
+        <line num="45" type="stmt" count="6"/>
+        <line num="62" type="stmt" count="6"/>
+        <line num="63" type="stmt" count="6"/>
+        <line num="64" type="stmt" count="6"/>
+        <line num="65" type="stmt" count="6"/>
+        <line num="66" type="stmt" count="6"/>
+        <line num="67" type="stmt" count="6"/>
+        <line num="69" type="stmt" count="6"/>
+        <line num="70" type="stmt" count="6"/>
+        <line num="71" type="stmt" count="6"/>
+        <line num="72" type="stmt" count="6"/>
+        <line num="73" type="stmt" count="6"/>
+        <line num="75" type="stmt" count="6"/>
+        <line num="76" type="stmt" count="6"/>
+        <line num="77" type="stmt" count="6"/>
+        <line num="78" type="stmt" count="6"/>
+        <line num="79" type="stmt" count="6"/>
+        <line num="83" type="stmt" count="6"/>
+        <line num="85" type="method" name="execute" visibility="protected" complexity="2" crap="2" count="6"/>
+        <line num="88" type="stmt" count="6"/>
+        <line num="89" type="stmt" count="6"/>
+        <line num="90" type="stmt" count="1"/>
+        <line num="91" type="stmt" count="1"/>
+        <line num="93" type="stmt" count="6"/>
+        <line num="95" type="method" name="showInstalledSections" visibility="private" complexity="2" crap="2" count="6"/>
+        <line num="97" type="stmt" count="6"/>
+        <line num="98" type="stmt" count="4"/>
+        <line num="100" type="stmt" count="6"/>
+        <line num="101" type="stmt" count="5"/>
+        <line num="103" type="method" name="getConfig" visibility="private" complexity="3" crap="3" count="6"/>
+        <line num="106" type="stmt" count="6"/>
+        <line num="107" type="stmt" count="6"/>
+        <line num="108" type="stmt" count="6"/>
+        <line num="109" type="stmt" count="6"/>
+        <line num="112" type="stmt" count="5"/>
+        <line num="113" type="stmt" count="1"/>
+        <line num="114" type="stmt" count="1"/>
+        <line num="115" type="stmt" count="1"/>
+        <line num="119" type="method" name="updateWhatRecord" visibility="private" complexity="11" crap="11.28" count="6"/>
+        <line num="121" type="stmt" count="6"/>
+        <line num="122" type="stmt" count="1"/>
+        <line num="126" type="stmt" count="5"/>
+        <line num="132" type="stmt" count="3"/>
+        <line num="133" type="stmt" count="1"/>
+        <line num="134" type="stmt" count="1"/>
+        <line num="135" type="stmt" count="1"/>
+        <line num="138" type="stmt" count="1"/>
+        <line num="139" type="stmt" count="0"/>
+        <line num="140" type="stmt" count="3"/>
+        <line num="144" type="stmt" count="2"/>
+        <line num="145" type="stmt" count="2"/>
+        <line num="146" type="stmt" count="2"/>
+        <line num="147" type="stmt" count="2"/>
+        <line num="148" type="stmt" count="2"/>
+        <line num="151" type="stmt" count="2"/>
+        <line num="152" type="stmt" count="2"/>
+        <line num="155" type="stmt" count="2"/>
+        <line num="156" type="stmt" count="0"/>
+        <line num="157" type="stmt" count="0"/>
+        <line num="160" type="stmt" count="2"/>
+        <line num="163" type="stmt" count="4"/>
+        <line num="164" type="stmt" count="4"/>
+        <line num="166" type="stmt" count="4"/>
+        <line num="167" type="stmt" count="2"/>
+        <line num="168" type="stmt" count="0"/>
+        <line num="169" type="stmt" count="0"/>
+        <line num="170" type="stmt" count="2"/>
+        <line num="171" type="stmt" count="2"/>
+        <line num="172" type="stmt" count="2"/>
+        <line num="177" type="stmt" count="4"/>
+        <line num="178" type="stmt" count="1"/>
+        <line num="181" type="stmt" count="4"/>
+        <line num="182" type="stmt" count="4"/>
+        <line num="183" type="stmt" count="2"/>
+        <line num="185" type="stmt" count="2"/>
+        <line num="187" type="stmt" count="2"/>
+        <line num="190" type="stmt" count="4"/>
+        <metrics loc="191" ncloc="170" classes="1" methods="6" coveredmethods="5" conditionals="0" coveredconditionals="0" statements="77" coveredstatements="72" elements="83" coveredelements="77"/>
       </file>
     </package>
     <package name="Tardigrades\DependencyInjection">
@@ -3366,6 +3415,6 @@
         <metrics loc="248" ncloc="143" classes="1" methods="16" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="38" coveredstatements="0" elements="54" coveredelements="0"/>
       </file>
     </package>
-    <metrics files="140" loc="8975" ncloc="7257" classes="118" methods="566" coveredmethods="543" conditionals="0" coveredconditionals="0" statements="1997" coveredstatements="1924" elements="2563" coveredelements="2467"/>
+    <metrics files="140" loc="9080" ncloc="7353" classes="118" methods="568" coveredmethods="545" conditionals="0" coveredconditionals="0" statements="2044" coveredstatements="1968" elements="2612" coveredelements="2513"/>
   </project>
 </coverage>

--- a/src/Command/UpdateFieldCommand.php
+++ b/src/Command/UpdateFieldCommand.php
@@ -62,7 +62,6 @@ class UpdateFieldCommand extends FieldCommand
     {
         try {
             $this->questionHelper = $this->getHelper('question');
-
             $this->showInstalledFields($input, $output);
         } catch (FieldNotFoundException $exception) {
             $output->writeln("Field not found");

--- a/src/Command/UpdateSectionCommand.php
+++ b/src/Command/UpdateSectionCommand.php
@@ -40,22 +40,18 @@ class UpdateSectionCommand extends SectionCommand
         // @codingStandardsIgnoreStart
         $this
             ->setDescription('Updates an existing section.')
-            //->setHelp('This command allows you to update a section based on a yml section configuration. Pass along the path to a section configuration yml. Something like: section/blog.yml')
             ->setHelp(<<<EOF
 The <info>%command.name%</info> command allows you to update a section based on a yml section cofiguration. Pass along the path to a section cofiguration yml. Something like: section/blog.yml
 
-You can automatically continue :
+You can automatically continue with flags:
 
-  <info>cat filename | php %command.full_name%</info>
+  <info>--yes-mode --in-history</info>
 
-You can also validate the syntax of a file:
+Will store the section config that will be replaced in history.
 
-  <info>php %command.full_name% filename</info>
+  <info>--yes-mode --not-in-history</info>
 
-Or of a whole directory:
-
-  <info>php %command.full_name% dirname</info>
-  <info>php %command.full_name% dirname --format=json</info>
+Will not store anything in history.
 
 EOF
             )
@@ -124,11 +120,6 @@ EOF
 
         try {
             $section = $this->sectionManager->readByHandle($sectionConfig->getHandle());
-
-//            echo "\n\n\n";
-//            var_dump($input->getOption('yes-mode'));
-//            echo "\n\n\n";
-
             if (!$input->getOption('yes-mode')) {
                 $sure = new ConfirmationQuestion(
                     '<comment>Do you want to update the section with id: ' . $section->getId() . '?</comment> (y/n) ',


### PR DESCRIPTION
This allows extra flags to the sf:update-section command that will make it pass automatically.

bin/console sf:update-section --yes-mode --in-history (will automatically choose to store previous setup in history)

bin/console sf:update-section --yes-mode --not-in-history (will automatically choose not to store previous setup in history)