### PR TITLE
Allow persisting entities without immediately flushing them

### DIFF
--- a/src/SectionField/Service/CreateSection.php
+++ b/src/SectionField/Service/CreateSection.php
@@ -57,4 +57,26 @@ class CreateSection implements CreateSectionInterface
             new SectionEntryCreated($sectionEntryEntity, $update)
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function persist(CommonSectionInterface $sectionEntryEntity, array $jitRelationships = null)
+    {
+        /** @var CreateSectionInterface $writer */
+        foreach ($this->creators as $writer) {
+            $writer->persist($sectionEntryEntity, $jitRelationships);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function flush()
+    {
+        /** @var CreateSectionInterface $writer */
+        foreach ($this->creators as $writer) {
+            $writer->flush();
+        }
+    }
 }

--- a/src/SectionField/Service/CreateSectionInterface.php
+++ b/src/SectionField/Service/CreateSectionInterface.php
@@ -38,4 +38,23 @@ interface CreateSectionInterface
      * @param array|null $jitRelationships
      */
     public function save(CommonSectionInterface $sectionEntryEntity, array $jitRelationships = null);
+
+    /**
+     * This method goes through all writers to persist a record, like save, but doesn't flush them.
+     *
+     * It's useful when many records have to be persisted. flush has to be called manually afterwards.
+     *
+     * No events are dispatched.
+     *
+     * @param CommonSectionInterface $sectionEntryEntity
+     * @param array|null $jitRelationships
+     */
+    public function persist(CommonSectionInterface $sectionEntryEntity, array $jitRelationships = null);
+
+    /**
+     * This method flushes all writers to store records that have been persisted.
+     *
+     * No events are dispatched.
+     */
+    public function flush();
 }

--- a/test/unit/SectionField/Service/CreateSectionTest.php
+++ b/test/unit/SectionField/Service/CreateSectionTest.php
@@ -132,4 +132,28 @@ final class CreateSectionTest extends TestCase
 
         $this->createSection->save($entry);
     }
+
+    /**
+     * @test
+     * @covers ::persist
+     */
+    public function it_should_persist_section()
+    {
+        $entry = Mockery::mock(CommonSectionInterface::class);
+        $this->creators[0]->shouldReceive('persist')->once();
+
+        $this->createSection->persist($entry);
+    }
+
+    /**
+     * @test
+     * @covers ::flush
+     */
+    public function it_should_flush_creators()
+    {
+        $entry = Mockery::mock(CommonSectionInterface::class);
+        $this->creators[0]->shouldReceive('flush')->once();
+
+        $this->createSection->flush($entry);
+    }
 }


### PR DESCRIPTION
Enables dionsnoeijen/sexy-field-doctrine#14 .