### PR TITLE
Use the "array" Doctrine data type for configs instead of "json_array"

### DIFF
--- a/src/config/xml/Tardigrades.Entity.Field.dcm.xml
+++ b/src/config/xml/Tardigrades.Entity.Field.dcm.xml
@@ -14,7 +14,7 @@
         </id>
         <field name="name" type="string" />
         <field name="handle" type="string" unique="true" />
-        <field name="config" type="json_array" />
+        <field name="config" type="array" />
         <field name="created" type="datetime" />
         <field name="updated" type="datetime" />
         <many-to-one

--- a/src/config/xml/Tardigrades.Entity.Section.dcm.xml
+++ b/src/config/xml/Tardigrades.Entity.Section.dcm.xml
@@ -15,7 +15,7 @@
         <field name="created" type="datetime" />
         <field name="updated" type="datetime" />
         <field name="name" type="string" />
-        <field name="config" type="json_array" />
+        <field name="config" type="array" />
         <field name="version" type="integer" />
         <one-to-many
             target-entity="Tardigrades\Entity\SectionHistory"

--- a/src/config/xml/Tardigrades.Entity.SectionHistory.dcm.xml
+++ b/src/config/xml/Tardigrades.Entity.SectionHistory.dcm.xml
@@ -11,7 +11,7 @@
         <field name="updated" type="datetime" />
         <field name="versioned" type="datetime" />
         <field name="name" type="string" />
-        <field name="config" type="json_array" />
+        <field name="config" type="array" />
         <field name="version" type="integer" />
         <many-to-one
             target-entity="Tardigrades\Entity\Section"


### PR DESCRIPTION
`json_array` is deprecated and doesn't seem to remember ordering properly. `array` uses `serialize` and `unserialize` so it's fairly reliable.