### PR TITLE
Expand CommonSectionInterface with common const and methods

### DIFF
--- a/src/SectionField/Generator/CommonSectionInterface.php
+++ b/src/SectionField/Generator/CommonSectionInterface.php
@@ -17,8 +17,14 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 interface CommonSectionInterface
 {
+    const FIELDS = [];
+
     public function getId(): ?int;
     public static function loadValidatorMetadata(ClassMetadata $metadata): void;
     public function onPrePersist(): void;
     public function onPreUpdate(): void;
+    public function getCreated(): ?\DateTime;
+    public function getUpdated(): ?\DateTime;
+    public function getSlug(): \Tardigrades\SectionField\ValueObject\Slug;
+    public function getDefault(): string;
 }

--- a/src/SectionField/Generator/CommonSectionInterface.php
+++ b/src/SectionField/Generator/CommonSectionInterface.php
@@ -17,8 +17,6 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 interface CommonSectionInterface
 {
-    const FIELDS = [];
-
     public function getId(): ?int;
     public static function loadValidatorMetadata(ClassMetadata $metadata): void;
     public function onPrePersist(): void;
@@ -27,4 +25,5 @@ interface CommonSectionInterface
     public function getUpdated(): ?\DateTime;
     public function getSlug(): \Tardigrades\SectionField\ValueObject\Slug;
     public function getDefault(): string;
+    public static function fieldInfo(): array;
 }

--- a/src/SectionField/Service/DefaultCache.php
+++ b/src/SectionField/Service/DefaultCache.php
@@ -7,6 +7,7 @@ namespace Tardigrades\SectionField\Service;
 use Psr\Cache\CacheItemInterface;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
+use Tardigrades\SectionField\Generator\CommonSectionInterface;
 use Tardigrades\SectionField\ValueObject\FullyQualifiedClassName;
 
 /**
@@ -32,7 +33,7 @@ class DefaultCache implements CacheInterface
 
     /** @var string */
     private $context;
-    
+
     /** @var string[] */
     private $relationships;
 
@@ -209,27 +210,21 @@ class DefaultCache implements CacheInterface
      *
      * @param FullyQualifiedClassName $fullyQualifiedClassName
      * @return array
-     * @throws UnableToGetEntityMetadataException
+     * @throws NotASexyFieldEntityException
      */
     private function getRelationships(FullyQualifiedClassName $fullyQualifiedClassName): array
     {
-        try {
-            $fields = (string)$fullyQualifiedClassName;
-            $relationships = [];
-            foreach ($fields::FIELDS as $field) {
-                try {
-                    if (!is_null($field['relationship']['class'])) {
-                        $relationships[] = $field['relationship']['class'];
-                    }
-                } catch (\Exception $exception) {
-                    // Just go on
-                }
-            }
-            return $relationships;
-        } catch (\Exception $exception) {
-            throw new UnableToGetEntityMetadataException(
-                'Cannot get ::FIELDS' . $exception->getMessage()
-            );
+        $fields = (string)$fullyQualifiedClassName;
+        if (!is_subclass_of($fields, CommonSectionInterface::class)) {
+            throw new NotASexyFieldEntityException;
         }
+        /** @var CommonSectionInterface $fields */
+        $relationships = [];
+        foreach ($fields::fieldInfo() as $field) {
+            if (!is_null($field['relationship'])) {
+                $relationships[] = $field['relationship']['class'];
+            }
+        }
+        return $relationships;
     }
 }

--- a/src/SectionField/Service/NotASexyFieldEntityException.php
+++ b/src/SectionField/Service/NotASexyFieldEntityException.php
@@ -9,14 +9,17 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Tardigrades\SectionField\Service;
 
-class UnableToGetEntityMetadataException extends \Exception
+class NotASexyFieldEntityException extends \UnexpectedValueException
 {
-    public function __construct($message = "", $code = 404, \Throwable $previous = null)
-    {
-        $message = !empty($message) ? $message : 'This entity does not seem to have metadata (::FIELDS)';
-
+    public function __construct(
+        $message = "This entity does not seem to belong to SexyField",
+        $code = 404,
+        \Throwable $previous = null
+    ) {
         parent::__construct($message, $code, $previous);
     }
 }


### PR DESCRIPTION
This adds the `FIELDS` const and certain methods that other code assumes exist to `CommonSectionInterface`.

It would be nice to also enforce the existence of those fields at the config level, but this change already ensures that any classes generated without those fields will be rejected.