### PR TITLE
Support delayed deletion of entities

### DIFF
--- a/src/SectionField/Service/DeleteSection.php
+++ b/src/SectionField/Service/DeleteSection.php
@@ -54,4 +54,18 @@ class DeleteSection implements DeleteSectionInterface
 
         return $success;
     }
+
+    public function remove(CommonSectionInterface $sectionEntryEntity): void
+    {
+        foreach ($this->deleters as $deleter) {
+            $deleter->remove($sectionEntryEntity);
+        }
+    }
+
+    public function flush(): void
+    {
+        foreach ($this->deleters as $deleter) {
+            $deleter->flush();
+        }
+    }
 }

--- a/src/SectionField/Service/DeleteSectionInterface.php
+++ b/src/SectionField/Service/DeleteSectionInterface.php
@@ -31,4 +31,8 @@ interface DeleteSectionInterface
      * @return bool
      */
     public function delete(CommonSectionInterface $sectionEntryEntity): bool;
+
+    public function remove(CommonSectionInterface $sectionEntryEntity): void;
+
+    public function flush(): void;
 }

--- a/test/unit/SectionField/Service/DeleteSectionTest.php
+++ b/test/unit/SectionField/Service/DeleteSectionTest.php
@@ -102,4 +102,25 @@ final class DeleteSectionTest extends TestCase
         $result = $this->deleteSection->delete($entry);
         $this->assertFalse($result);
     }
+
+    /**
+     * @test
+     * @covers ::remove
+     */
+    public function it_should_remove_successfully()
+    {
+        $entry = Mockery::mock(CommonSectionInterface::class);
+        $this->deleters[0]->shouldReceive('remove')->once()->with($entry);
+        $this->deleteSection->remove($entry);
+    }
+
+    /**
+     * @test
+     * @covers ::flush
+     */
+    public function it_should_flush_successfully()
+    {
+        $this->deleters[0]->shouldReceive('flush')->once();
+        $this->deleteSection->flush();
+    }
 }


### PR DESCRIPTION
You can now do a `remove` separate from a `flush`.

See also: dionsnoeijen/sexy-field-doctrine#29