### PR TITLE
Add a ::flush method to ReadSection

### DIFF
--- a/src/SectionField/Service/ReadSection.php
+++ b/src/SectionField/Service/ReadSection.php
@@ -20,7 +20,7 @@ use Tardigrades\SectionField\ValueObject\SectionConfig;
 
 class ReadSection implements ReadSectionInterface
 {
-    /** @var array */
+    /** @var ReadSectionInterface[] */
     private $readers;
 
     /** @var SectionManagerInterface */
@@ -82,5 +82,12 @@ class ReadSection implements ReadSectionInterface
         );
 
         return $sectionData;
+    }
+
+    public function flush(): void
+    {
+        foreach ($this->readers as $reader) {
+            $reader->flush();
+        }
     }
 }

--- a/src/SectionField/Service/ReadSectionInterface.php
+++ b/src/SectionField/Service/ReadSectionInterface.php
@@ -18,4 +18,6 @@ use Tardigrades\SectionField\ValueObject\SectionConfig;
 interface ReadSectionInterface
 {
     public function read(ReadOptionsInterface $options, SectionConfig $sectionConfig = null): \ArrayIterator;
+
+    public function flush(): void;
 }

--- a/test/unit/SectionField/Service/ReadSectionTest.php
+++ b/test/unit/SectionField/Service/ReadSectionTest.php
@@ -115,6 +115,13 @@ final class ReadSectionTest extends TestCase
         $this->assertEquals(new \ArrayIterator(), $result);
     }
 
+    /** @test */
+    public function it_should_flush()
+    {
+        $this->readers[0]->shouldReceive('flush')->once();
+        $this->readSection->flush();
+    }
+
     private function givenASectionWithName($name)
     {
         $sectionName = 'Section ' . $name;

--- a/test/unit/SectionField/Service/ReadSectionTest.php
+++ b/test/unit/SectionField/Service/ReadSectionTest.php
@@ -115,7 +115,10 @@ final class ReadSectionTest extends TestCase
         $this->assertEquals(new \ArrayIterator(), $result);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @covers ::flush
+     */
     public function it_should_flush()
     {
         $this->readers[0]->shouldReceive('flush')->once();


### PR DESCRIPTION
This adds a `::flush` method to `ReadSection`, so changes to entities can be saved without breaking the abstraction.