### PR TITLE
Only try to mkdir if the dir doesn't exist

### DIFF
--- a/src/SectionField/Generator/Writer/GeneratorFileWriter.php
+++ b/src/SectionField/Generator/Writer/GeneratorFileWriter.php
@@ -24,7 +24,9 @@ class GeneratorFileWriter
         $path = self::getPsr4AutoloadDirectoryForNamespace($writable->getNamespace());
         $store = $path . $writable->getFilename();
 
-        \mkdir($path, 0755, true);
+        if (!\file_exists($path)) {
+            \mkdir($path, 0755, true);
+        }
 
         try {
             if (\file_exists($store)) {


### PR DESCRIPTION
Otherwise Symfony crashes on the warning.
I thought I tested that, but apparently I didn't.