### PR TITLE
Allow Writables to be marked as non-clobbering

### DIFF
--- a/src/SectionField/Generator/Writer/GeneratorFileWriter.php
+++ b/src/SectionField/Generator/Writer/GeneratorFileWriter.php
@@ -30,6 +30,9 @@ class GeneratorFileWriter
 
         try {
             if (\file_exists($store)) {
+                if (!$writable->shouldClobber()) {
+                    return;
+                }
                 $segments = explode(
                     '/',
                     $store

--- a/src/SectionField/Generator/Writer/Writable.php
+++ b/src/SectionField/Generator/Writer/Writable.php
@@ -24,14 +24,19 @@ class Writable
     /** @var string */
     private $filename;
 
+    /** @var bool */
+    private $clobber;
+
     private function __construct(
         string $template,
         string $namespace,
-        string $filename
+        string $filename,
+        bool $clobber = true
     ) {
         $this->template = $template;
         $this->namespace = $namespace;
         $this->filename = $filename;
+        $this->clobber = $clobber;
     }
 
     public function getTemplate(): string
@@ -49,11 +54,17 @@ class Writable
         return $this->filename;
     }
 
+    public function shouldClobber(): bool
+    {
+        return $this->clobber;
+    }
+
     public static function create(
         string $template,
         string $namespace,
-        string $filename
+        string $filename,
+        bool $clobber = true
     ): self {
-        return new self($template, $namespace, $filename);
+        return new static($template, $namespace, $filename, $clobber);
     }
 }


### PR DESCRIPTION
If a Writable is created with $clobber = false, then it won't overwrite an existing file, so it's only created the first time.

This is needed for the extra methods in traits feature.