### PR TITLE
Add ...$options to GeneratorInterface::generate

### DIFF
--- a/src/FieldType/Generator/GeneratorInterface.php
+++ b/src/FieldType/Generator/GeneratorInterface.php
@@ -19,5 +19,5 @@ use Tardigrades\FieldType\ValueObject\TemplateDir;
 
 interface GeneratorInterface
 {
-    public static function generate(FieldInterface $field, TemplateDir $templateDir): Template;
+    public static function generate(FieldInterface $field, TemplateDir $templateDir, ...$options): Template;
 }


### PR DESCRIPTION
Psalm was giving issues because some classes implement this method with the extra argument `...$options`.
Therefore it was added to the interface.
Before merging all implementations should be updated